### PR TITLE
feat: add CI with dynamic skill test discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      skills: ${{ steps.find.outputs.skills }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Discover skills with tests
+        id: find
+        run: |
+          skills=$(find claudio-plugin/skills -type d -name tests \
+            | sed 's|/tests$||' \
+            | jq -R . | jq -sc .)
+          echo "skills=$skills" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: discover
+    if: needs.discover.outputs.skills != '[]'
+    runs-on: ubuntu-latest
+    container:
+      image: registry.access.redhat.com/ubi10/python-312-minimal:latest
+    strategy:
+      fail-fast: false
+      matrix:
+        skill: ${{ fromJson(needs.discover.outputs.skills) }}
+    name: Test ${{ matrix.skill }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install test dependencies
+        run: |
+          if [ -f "${{ matrix.skill }}/requirements-test.txt" ]; then
+            pip install -r "${{ matrix.skill }}/requirements-test.txt" -q
+          fi
+      - name: Run pytest
+        working-directory: "${{ matrix.skill }}"
+        run: python -m pytest tests/ -v


### PR DESCRIPTION
## Summary

* Add GitHub Actions workflow with two-job pipeline (discover + test)
* Discovery job dynamically finds all skills with a `tests/` directory — new skills are picked up automatically with no workflow changes
* Test job runs `pytest` inside `registry.access.redhat.com/ubi9/python-311:latest` per discovered skill
* `fail-fast: false` ensures all skills are tested even if one fails

## Local testing

Works with `act` via rootless Podman:

```bash
act pull_request
```

Signed-off-by: Jakub Rusz <jrusz@redhat.com>