### PR TITLE
fix: switch to ubi9/python-312 image for CI test container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     if: needs.discover.outputs.skills != '[]'
     runs-on: ubuntu-latest
     container:
-      image: registry.access.redhat.com/ubi10/python-312-minimal:latest
+      image: registry.access.redhat.com/ubi9/python-312:latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

`ubi10/python-312-minimal` doesn't ship `tar` or `git`, which `actions/checkout@v4` needs to extract the repo archive inside the container. Switch to `ubi9/python-312` which is the non-minimal variant and includes both.

Fixes the failure introduced after merging #15.

Signed-off-by: Jakub Rusz <jrusz@redhat.com>