### PR TITLE
feat: add release-delta skill for AIPCC Wheels Builder changelog gene…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Claude Code plugin that extends Claude with specialized skills for DevOps and 
 
 ## Overview
 
-Claudio Skills Plugin provides four production-ready skills designed to streamline interactions with GitLab CI/CD, Konflux, AWS CloudWatch Logs, and Slack. Each skill provides Claude Code with domain-specific capabilities, allowing you to leverage Claude as an intelligent assistant for complex DevOps tasks.
+Claudio Skills Plugin provides five production-ready skills designed to streamline interactions with GitLab CI/CD, Konflux, AWS CloudWatch Logs, Slack, and release changelog generation. Each skill provides Claude Code with domain-specific capabilities, allowing you to leverage Claude as an intelligent assistant for complex DevOps tasks.
 
 ## Features
 
@@ -15,6 +15,7 @@ Claudio Skills Plugin provides four production-ready skills designed to streamli
 - **Konflux Release Orchestration** - Automate stage-to-production release workflows on the Konflux platform
 - **AWS Log Analysis** - Troubleshoot and analyze CloudWatch Logs with advanced querying
 - **Slack Utilities** - Search messages, post updates, and interact with Slack workspaces
+- **Release Delta Generation** - Generate comprehensive release changelogs between AIPCC Wheels Builder versions with customizable sections
 
 ## Skills
 
@@ -98,6 +99,29 @@ it should be something similar to `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/5
 
 Disclaimer, the first time you reuse those Tokens you will probably be signed off as precaution, the second time you sign in the tokens should last.
 
+### 5. Release Delta Skill
+
+Generate comprehensive release changelog documentation between two versions of the **AIPCC Wheels Builder** repository (`git@gitlab.com:redhat/rhel-ai/wheels/builder.git`).
+
+**Use Cases:**
+- Generate full Builder release changelogs with all details
+- Extract specific sections (highlights, upgrade notes, JIRA issues)
+- Create executive summaries for Product Owners and sprint reporting
+- Document release impact analysis for Builder releases
+- Track contributors and release metrics across Builder versions
+
+**Key Features:**
+- Customizable section filtering (header, timeline, highlights, releases, summary, impact, jira, upgrade, contributors, references)
+- Git-based data collection (tags, commits, release notes)
+- Comprehensive release metrics and JIRA ticket tracking
+- Markdown output suitable for documentation and reporting
+- Supports partial reports for quick stakeholder updates
+
+**Section Options:**
+- `--sections highlights` - Executive summary only
+- `--sections header,timeline,highlights,impact` - Executive overview
+- `--sections all` - Full comprehensive report (default)
+
 ## Installation
 
 ### Prerequisites
@@ -116,6 +140,7 @@ Each skill manages its own dependencies through installer scripts in `claudio-pl
 | Konflux Release | `kubectl`, `glab`, `skopeo`, `python3` + PyYAML, `jq` | `kubectl`, `skopeo`, `jq`, PyYAML |
 | AWS Log Analyzer | `aws` CLI v2, `jq` | Both |
 | Slack Utilities | `curl`, `jq`, `python3` + requests | `jq`, requests |
+| Release Delta | `git`, `glab` | None (uses system git) |
 
 **Authentication:**
 - GitLab: Authenticate with `glab auth login` before using (required for GitLab Job Analyzer and Konflux Release)
@@ -231,9 +256,11 @@ claudio-plugin/
     ├── aws-log-analyzer/
     │   ├── SKILL.md             # AWS CloudWatch Logs analysis skill
     │   └── scripts/             # Log analysis scripts
-    └── slack-utilities/
-        ├── SKILL.md             # Slack Web API skill
-        └── scripts/             # Slack interaction scripts
+    ├── slack-utilities/
+    │   ├── SKILL.md             # Slack Web API skill
+    │   └── scripts/             # Slack interaction scripts
+    └── release-delta/
+        └── SKILL.md             # Release changelog generation skill
 ```
 
 ## Tool Management
@@ -302,6 +329,7 @@ Each skill includes its own test scenarios. Run skill-specific scripts directly 
 - [Konflux Release Skill](claudio-plugin/skills/konflux-release/SKILL.md)
 - [AWS Log Analyzer Skill](claudio-plugin/skills/aws-log-analyzer/SKILL.md)
 - [Slack Utilities Skill](claudio-plugin/skills/slack-utilities/SKILL.md)
+- [Release Delta Skill](claudio-plugin/skills/release-delta/SKILL.md)
 
 ## Contributing
 

--- a/claudio-plugin/skills/release-delta/SKILL.md
+++ b/claudio-plugin/skills/release-delta/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: release-delta
+description: Generate comprehensive release changelog documentation between two builder versions. Accepts old_version and new_version as arguments.
+---
+
+# Release Delta Generator
+
+Generate comprehensive release changelog documentation between two versions of the AIPCC Wheels Builder.
+
+## Parameters
+
+- `old_version`: The starting version (e.g., v26.0.0)
+- `new_version`: The ending version (e.g., v26.4.0)
+- `--sections` (optional): Comma-separated list of sections to include in the output
+
+### Available Sections
+
+- `header` - Header section with dates, commits, releases count
+- `timeline` - Release Timeline Table
+- `highlights` - Key Highlights Section (executive summary)
+- `releases` - Individual Release Sections (detailed notes)
+- `summary` - Summary by Category
+- `impact` - Impact Analysis
+- `jira` - JIRA Issues Addressed
+- `upgrade` - Upgrade Notes
+- `contributors` - Contributors
+- `references` - References
+- `all` - All sections (default if --sections not specified)
+
+## Usage
+
+```bash
+# Full report (all sections)
+/release-delta v26.0.0 v26.4.0
+
+# Only key highlights
+/release-delta v26.0.0 v26.4.0 --sections highlights
+
+# Multiple specific sections
+/release-delta v26.0.0 v26.4.0 --sections header,timeline,highlights
+
+# Executive summary (header + timeline + highlights)
+/release-delta v26.0.0 v26.4.0 --sections header,timeline,highlights,impact
+
+# Quick overview (no detailed releases)
+/release-delta v26.0.0 v26.4.0 --sections header,timeline,highlights,summary,upgrade
+```
+
+## Instructions
+
+When this skill is invoked:
+
+1. **Parse the parameters** from the skill arguments:
+   - Extract old_version and new_version
+   - Extract --sections parameter if provided (defaults to "all")
+   - Parse sections into a list (e.g., "header,timeline,highlights" → ["header", "timeline", "highlights"])
+   - If old_version or new_version not provided, ask the user for them using AskUserQuestion
+   - Validate section names against available sections list
+
+2. **Update the repository**:
+   - Run `git fetch --tags upstream` to get latest tags from upstream
+   - Run `git pull upstream main` to update main branch
+
+3. **Validate versions**:
+   - Verify both version tags exist in the repository
+   - If either tag doesn't exist, inform the user and list available recent tags
+
+4. **Collect release information**:
+   - Get the list of all version tags between old_version and new_version (inclusive of new_version, exclusive of old_version)
+   - For each release tag:
+     - Get the release date: `git log -1 --format='%ad' --date=short <tag>`
+     - Get the tagger: `git for-each-ref --format='%(taggername) <%(taggeremail)>' refs/tags/<tag>`
+     - Get the release notes: `git show <tag> --no-patch --format="%N" | tail -n +3`
+     - Get the commit hash: `git log -1 --format="%H" <tag>`
+
+5. **Collect commit details**:
+   - Get all commits between versions: `git log <old_version>..<new_version> --oneline --no-merges --reverse`
+   - Count total commits: `git log <old_version>..<new_version> --oneline --no-merges | wc -l`
+
+6. **Generate the changelog document** based on requested sections:
+   - If --sections is "all" or not specified, include all sections
+   - Otherwise, only include the sections specified in the --sections parameter
+   - Always maintain the order: header → timeline → highlights → releases → summary → impact → jira → upgrade → contributors → references → footer
+
+   **Section Definitions:**
+
+   **Header Section (section: "header"):**
+   - Title: "AIPCC Wheels Builder - Changelog <old_version> to <new_version>"
+   - Period dates (start to end)
+   - Total commits count
+   - Total releases count
+   - Repository URL: https://gitlab.com/redhat/rhel-ai/wheels/builder
+
+   **Release Timeline Table (section: "timeline"):**
+   - Columns: Version | Date | Released By | Type
+   - List all releases chronologically
+
+   **Key Highlights Section (section: "highlights"):**
+   This executive summary section appears immediately after the Release Timeline Table and before detailed release notes.
+
+   Structure:
+   - **Introduction paragraph**: Brief overview of the release cycle's main themes
+
+   - **Major Features:**
+     - Group by category (e.g., "New Accelerator Platform Support", "vLLM Ecosystem Expansion", "Performance Optimizations")
+     - Use bullet points with bold package/feature names and clear descriptions
+     - Include specific version numbers and platform details
+
+   - **Stability & Build Improvements:**
+     - "PyTorch Ecosystem Constraints" section listing all constraint fixes
+     - "Package Build Fixes" section listing resolved build issues
+     - Use bullet points with package names in bold
+
+   - **Enhanced Package Building:**
+     - Highlight source-based builds and build system improvements
+     - Note any new build capabilities
+
+   - **Development Tools & Infrastructure:**
+     - CI/CD improvements
+     - Tooling updates
+     - Developer experience enhancements
+
+   - **Release Metrics:**
+     - Number of releases and timespan
+     - Total commits
+     - JIRA tickets count
+     - Major feature areas count
+     - Release managers with contribution counts
+
+   - **Impact Summary:**
+     - 3-4 concise impact statements covering:
+       - Platform/accelerator expansion
+       - Ecosystem maturity
+       - Production readiness
+       - Performance improvements
+     - Each statement: Bold topic followed by explanation (1-2 sentences)
+
+   End with horizontal rule before "Detailed Release Notes" heading.
+
+   **Individual Release Sections (section: "releases", newest first):**
+   For each release:
+   - Release version and date
+   - Released by (name and email)
+   - Commit hash
+   - Features section (issues marked with [Feat])
+   - Fixes section (issues marked with [Fix])
+   - Other sections as needed (Chore, Refactor, etc.)
+   - List of commit hashes with descriptions
+
+   **Summary by Category (section: "summary"):**
+   - Group all changes by type: Features, Bug Fixes, Maintenance
+   - Provide high-level summaries of major changes
+   - Organize by functional area (e.g., vLLM, CUDA, Torch ecosystem, etc.)
+
+   **Impact Analysis (section: "impact"):**
+   - Describe impact of major features
+   - Note any breaking changes
+   - Highlight platform/accelerator additions
+
+   **JIRA Issues Addressed (section: "jira"):**
+   - Count unique JIRA issues
+   - Group by component/area
+
+   **Upgrade Notes (section: "upgrade"):**
+   - Breaking changes (if any)
+   - New features available
+   - Important constraints to note
+   - Recommended actions
+
+   **Contributors (section: "contributors"):**
+   - List release managers and contribution counts
+
+   **References (section: "references"):**
+   - Repository URL
+   - Release page URL
+   - Documentation references
+
+   **Footer (always included):**
+   - Generation date
+   - Source (git tag range)
+
+7. **Save the document**:
+   - Create filename based on sections:
+     - If all sections: `RELEASE_CHANGES_<old_version>_to_<new_version>.md`
+     - If filtered sections: `RELEASE_CHANGES_<old_version>_to_<new_version>_<sections>.md`
+       - Example: `RELEASE_CHANGES_v26.0.0_to_v26.4.0_highlights.md`
+       - For multiple sections: `RELEASE_CHANGES_v26.0.0_to_v26.4.0_highlights-summary.md`
+   - Save to the current working directory
+   - Inform the user of the file location
+
+8. **Summary**:
+   - Provide a brief summary of what was generated
+   - Include: number of releases, date range, sections included
+   - If only specific sections were requested, mention which sections were included
+   - Show the file path as a clickable link
+
+## Output Format
+
+The generated document should be in Markdown format, well-structured, and suitable for Product Owner review and sprint reporting.
+
+## Error Handling
+
+- If git fetch fails, inform the user and suggest checking network/credentials
+- If version tags don't exist, list recent available tags
+- If no commits found between versions, inform the user
+- If upstream remote doesn't exist, suggest adding it with:
+  ```
+  git remote add upstream git@gitlab.com:redhat/rhel-ai/wheels/builder.git
+  ```
+
+## Notes
+
+- This skill focuses on the upstream repository at `git@gitlab.com:redhat/rhel-ai/wheels/builder.git`
+- Include all commit details and JIRA ticket references for traceability
+- Organize information for easy scanning by Product Owners and stakeholders
+
+### Section Filtering Behavior
+
+- **Default (no --sections)**: Generate full report with all sections
+- **--sections all**: Explicitly generate full report (same as default)
+- **--sections <specific>**: Generate only the requested sections
+- **Data collection**: Always collect all data regardless of sections requested (needed for cross-references)
+- **Section order**: Always maintain the canonical order even when filtering
+- **Footer**: Always included regardless of section filtering
+- **Invalid sections**: If an invalid section name is provided, inform the user and list valid options
+
+## Key Highlights Section Example
+
+The Key Highlights section should be comprehensive yet scannable. Use the following structure:
+
+```markdown
+## Key Highlights
+
+This release cycle (vX.X.X to vY.Y.Y) introduces [main themes].
+
+### Major Features
+
+#### Category Name
+- **Package/Feature Name** - Description with specifics
+- **Another Feature** - Details including versions and platforms
+
+### Stability & Build Improvements
+
+#### PyTorch Ecosystem Constraints (N fixes)
+Critical version constraints to ensure reproducible, stable builds:
+
+- **Package**: Constraint details
+- **Another Package**: Constraint details
+
+#### Package Build Fixes
+- **package-name**: Fix description
+- **another-package**: Fix description
+
+### Enhanced Package Building
+
+#### Source-Based Builds
+- **packages**: Description
+  - Additional details
+  - More context
+
+### Development Tools & Infrastructure
+- **Tool/Area**: Description
+- **Another Area**: Description
+
+### Release Metrics
+
+- **N releases** over X days (Date1 - Date2)
+- **N commits** with no merges
+- **N+ JIRA tickets** resolved across multiple components
+- **N major feature areas**: Area1, Area2, Area3
+- **N release managers**: Name1 (X releases), Name2 (Y releases)
+
+### Impact Summary
+
+**Topic**: One to two sentence explanation of impact and importance.
+
+**Another Topic**: Description of significance and benefit.
+
+**Third Topic**: Explanation of improvement or addition.
+
+**Fourth Topic**: Impact statement with specific details.
+```


### PR DESCRIPTION
## Summary

Add new release-delta skill that generates comprehensive release changelog documentation between two versions of the AIPCC Wheels Builder repository.

## Features

- **Builder-specific**: Targets `redhat/rhel-ai/wheels/builder` GitLab repository
- **Customizable sections**: Generate full reports or extract specific sections (highlights, timeline, releases, impact, JIRA, upgrade notes, etc.)
- **Git-based data collection**: Automatically collects tags, commits, and release notes
- **Release metrics**: Track contributors, JIRA tickets, and release statistics
- **Markdown output**: Suitable for documentation and sprint reporting

## Usage Examples

```bash
# Full comprehensive report
/release-delta v28.4.0 v28.11.0

# Executive summary only
/release-delta v28.4.0 v28.11.0 --sections highlights

# Custom sections
/release-delta v28.4.0 v28.11.0 --sections header,timeline,highlights,impact
Changes
Add claudio-plugin/skills/release-delta/SKILL.md with complete skill definition
Update README.md with Release Delta skill documentation
Add to skill catalog in Features, Skills, Architecture, and Documentation sections
Testing
Tested with:

/release-delta v28.4.0 v28.11.0 --sections highlights
Generated executive summary successfully with 7 releases, 34 commits, 8-day period