### PR TITLE
feat: add Renovate configuration for automated dependency updates

### DIFF
--- a/claudio-plugin/tools/aws-cli/install.sh
+++ b/claudio-plugin/tools/aws-cli/install.sh
@@ -23,7 +23,7 @@ source "$SCRIPT_DIR/../common.sh"
 # DEPENDENCY VERSION
 # ============================================================================
 # This version is tracked by Renovate for automatic updates
-# renovate: datasource=github-releases depName=aws/aws-cli
+# renovate: datasource=github-tags depName=aws/aws-cli
 AWS_CLI_VERSION="2.15.17"
 
 # ============================================================================

--- a/renovate.json
+++ b/renovate.json
@@ -8,12 +8,13 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^claudio-plugin/tools/.+/install\.sh$/"
+        "/^claudio-plugin/tools/.+/install\\.sh$/"
       ],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)(?:\\s+registryUrl=(?<registryUrl>[^\\s]+))?\\n[A-Z_]+_VERSION=\"(?<currentValue>[^\"]+)\""
       ],
-      "versioningTemplate": "semver"
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^(?:v|jq-)?(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `renovate.json` to enable automated dependency update PRs via the Renovate bot
- Extends the shared preset from `gitlab>redhat/rhel-ai/renovate-config` using `gitlab>` prefix (instead of `local>`) since this is a GitHub-hosted repo referencing a GitLab-hosted preset
- Targets only the `main` branch
- Fix aws-cli renovate comment to use `github-tags` datasource (the repo has no GitHub Releases, only tags)

## What Renovate will track

**Via custom regex manager (4 deps):** tool installer versions in `claudio-plugin/tools/*/install.sh` — kubectl, glab, jq, aws-cli

**Via built-in managers (auto-detected):** GitHub Actions in CI workflow, pip requirements across skills, Docker images in CI

## Key design decisions

- `gitlab>` preset reference allows the Renovate runner (which has `GITLAB_COM_TOKEN` in hostRules) to fetch the private shared config from gitlab.com
- `extractVersionTemplate` handles both `v`-prefixed tags (kubernetes) and `jq-` prefixed tags (jqlang/jq)
- aws-cli uses `github-tags` datasource because `aws/aws-cli` publishes only tags, not GitHub Releases
- No `packageRules` needed — the shared preset provides sensible defaults (automerge disabled, `group:all`, `:gitSignOff`)

## Test plan

- [x] Ran Renovate locally in dry-run mode — preset resolves, all 4 custom-managed deps detected
- [x] Ran Renovate without dry-run — https://github.com/srija-ganguly/claudio-skills/pull/5  created with updates for all 4 tool versions
- [x] Verified no auto-merge (PR requires manual review)