### PR TITLE
AIPCC-9338: add renovate-pipelinerun skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,14 @@ claudio-plugin/
                 ├── get_board.sh         # Discover boards for a project
                 ├── cve_tracker.sh       # CVE deduplication and release clustering
                 └── setup_auth.sh        # One-time acli authentication
+    └── renovate-pipelinerun/
+        ├── SKILL.md             # Renovate PipelineRun trigger and monitor skill
+            └── scripts/
+                ├── check_auth.sh        # OpenShift auth and namespace validation
+                ├── list_pipelines.sh    # List available Renovate pipelines
+                ├── start_pipeline.sh    # Start a PipelineRun with busy-check
+                ├── get_status.sh        # PipelineRun status and TaskRun summary
+                └── get_logs.sh          # Retrieve PipelineRun/TaskRun logs
 ```
 
 
@@ -148,6 +156,11 @@ source "$SCRIPT_DIR/../common.sh"
 - Installs skopeo via system package manager (dnf/apt/apk)
 - Used by: konflux-release skill
 - Supports: Linux (RHEL, Fedora, Ubuntu, Debian, Alpine)
+
+**tkn** (`tools/tkn/install.sh`)
+- Installs tkn (Tekton CLI)
+- Used by: renovate-pipelinerun skill
+- Supports: Linux x86_64, ARM64
 
 ### Adding New Tools
 
@@ -363,6 +376,25 @@ When a new version is released, Renovate automatically creates a PR to update th
 - Custom fields (priority, component, team, activity-type) applied via REST PATCH
 - CVE deduplication and release-date clustering via embedded jq analysis
 
+### 6. Renovate PipelineRun Skill
+
+**Purpose:** Trigger and monitor self-hosted Renovate PipelineRuns on OpenShift via Tekton.
+
+**Use cases:**
+- List available Renovate pipelines on the cluster
+- Start a PipelineRun for a specific pipeline with busy-checking
+- Check PipelineRun and TaskRun status
+- Retrieve logs from PipelineRuns and TaskRuns
+- View recent PipelineRun history
+
+**Key features:**
+- Cluster authentication validation before operations
+- Dynamic pipeline discovery (filters by `renovate-` prefix)
+- Busy-check logic matching the production CronJob behavior
+- JSON output for programmatic parsing
+- Configurable log line limits to avoid context overflow
+- Uses `tkn` and `kubectl` CLIs (both auto-installed)
+
 ## Prerequisites
 
 Each skill has its own dependencies:
@@ -394,6 +426,11 @@ Each skill has its own dependencies:
 - `JIRA_SITE` - Atlassian site hostname (e.g., `yourorg.atlassian.net` — no `https://` prefix)
 - `JIRA_TOKEN` - API token from Atlassian account settings → Security → API tokens
 - `JIRA_EMAIL` - Your Atlassian account email
+
+**Renovate PipelineRun Skill:**
+- `kubectl` - Kubernetes CLI (installed via `tools/kubectl/install.sh`)
+- `tkn` - Tekton CLI (installed via `tools/tkn/install.sh`)
+- `RENOVATE_NAMESPACE` - OpenShift namespace (defaults to `rhel-ai-cicd--renovate-runner`)
 
 ## Installation
 

--- a/claudio-plugin/skills/renovate-pipelinerun/SKILL.md
+++ b/claudio-plugin/skills/renovate-pipelinerun/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: renovate-pipelinerun
+description: Trigger and monitor Renovate PipelineRuns on OpenShift. Use this skill when the user asks to run Renovate, start a Renovate pipeline, check Renovate run status, view Renovate logs, or list available Renovate pipelines. Wraps tkn and kubectl CLI commands for Tekton PipelineRun management.
+allowed-tools: Bash(*/renovate-pipelinerun/scripts/*.sh:*),Bash(*/tools/*/install.sh:*)
+---
+
+# Renovate PipelineRun
+
+## Overview
+
+Trigger and monitor self-hosted Renovate PipelineRuns on OpenShift via Tekton. This skill automates cluster authentication validation, pipeline discovery, busy-checking, PipelineRun creation, status monitoring, and log retrieval.
+
+**Prerequisites:**
+- `kubectl` installed (auto-installed via `tools/kubectl/install.sh`) and authenticated to the cluster
+- `tkn` command available (auto-installed via `tools/tkn/install.sh`)
+- `RENOVATE_NAMESPACE` environment variable (defaults to `rhel-ai-cicd--renovate-runner`)
+
+## Example Usage
+
+List available pipelines:
+> /renovate-pipelinerun list available Renovate pipelines
+
+Start a pipeline (dry-run — no actual execution):
+> /renovate-pipelinerun dry-run start of renovate-rhelai-core
+
+Start a pipeline for real:
+> /renovate-pipelinerun start renovate-rhelai-core
+
+Start even if busy:
+> /renovate-pipelinerun force start renovate-rhelai-core
+
+Check status of a pipeline (shows most recent run):
+> /renovate-pipelinerun what's the status of renovate-rhelai-core?
+
+Check status of a specific PipelineRun:
+> /renovate-pipelinerun status of renovate-rhelai-core-run-abc123
+
+Show recent runs across all pipelines:
+> /renovate-pipelinerun show recent Renovate activity
+
+Show last 5 runs for a pipeline:
+> /renovate-pipelinerun show last 5 runs of renovate-rhelai-wheels
+
+View logs from a PipelineRun:
+> /renovate-pipelinerun show logs for renovate-rhelai-core-run-abc123
+
+View last 50 lines of logs:
+> /renovate-pipelinerun show last 50 lines of logs for renovate-rhelai-core-run-abc123
+
+## Scripts
+
+All scripts are in the `scripts/` directory and must be invoked with their full absolute path.
+
+### check_auth.sh
+
+Validate cluster authentication and namespace configuration.
+
+```bash
+/full/path/to/renovate-pipelinerun/scripts/check_auth.sh
+```
+
+Checks:
+- `kubectl` is installed and user is authenticated
+- `RENOVATE_NAMESPACE` namespace exists on the cluster
+
+### list_pipelines.sh
+
+List available Renovate pipelines in the configured namespace.
+
+```bash
+/full/path/to/renovate-pipelinerun/scripts/list_pipelines.sh
+```
+
+Output: JSON array of pipelines with name and creation timestamp, filtered to the `renovate-` prefix.
+
+### start_pipeline.sh
+
+Start a PipelineRun for a specified Renovate pipeline.
+
+```bash
+/full/path/to/renovate-pipelinerun/scripts/start_pipeline.sh <pipeline-name> [--force] [--dry-run]
+```
+
+Arguments:
+- `pipeline-name` — Name of the pipeline (e.g., `renovate-rhelai-core`)
+- `--force` — Start even if the pipeline is currently busy (skip busy-check warning)
+- `--dry-run` — Output the PipelineRun YAML without creating it
+
+Behavior:
+- Validates auth and namespace
+- Checks if the pipeline exists
+- Checks if the pipeline is busy (has active TaskRuns)
+- If busy, reports the active PipelineRun and exits with code 2 (use `--force` to override)
+- Starts the PipelineRun with: `--serviceaccount renovate-admin`, `--pipeline-timeout 2h`, `-w name=shared-workspace,emptyDir=""`, `--use-param-defaults`
+- Reports the created PipelineRun name
+
+### get_status.sh
+
+Get the status of a PipelineRun or the most recent run for a pipeline.
+
+```bash
+/full/path/to/renovate-pipelinerun/scripts/get_status.sh <name> [--history N]
+/full/path/to/renovate-pipelinerun/scripts/get_status.sh --all [--history N]
+```
+
+Arguments:
+- `name` — A PipelineRun name or pipeline name (auto-detects which)
+- `--history N` — List the last N PipelineRuns instead of showing details (default: 10)
+- `--all` — Show runs across all `renovate-` pipelines
+
+Output: JSON with PipelineRun details including status, start time, duration, and TaskRun summary.
+
+### get_logs.sh
+
+Retrieve logs from a PipelineRun or TaskRun.
+
+```bash
+/full/path/to/renovate-pipelinerun/scripts/get_logs.sh <name> [--lines N]
+```
+
+Arguments:
+- `name` — A PipelineRun name or TaskRun name
+- `--lines N` — Number of log lines to retrieve (default: 200)
+
+## Script Execution Requirements
+
+1. **Single-line commands only** — NO line breaks or backslash continuations
+2. **DO NOT change directory** — execute scripts using their full absolute path
+3. **Full path required** — the script must be invoked with its full filesystem path

--- a/claudio-plugin/skills/renovate-pipelinerun/scripts/_common.sh
+++ b/claudio-plugin/skills/renovate-pipelinerun/scripts/_common.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Common helpers for renovate-pipelinerun scripts.
+# Sourced by all scripts in this directory.
+#
+# Environment variables:
+#   RENOVATE_NAMESPACE - OpenShift namespace (default: rhel-ai-cicd--renovate-runner)
+
+set -euo pipefail
+
+_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_TOOLS_DIR="$_COMMON_DIR/../../../tools"
+
+RENOVATE_NAMESPACE="${RENOVATE_NAMESPACE:-rhel-ai-cicd--renovate-runner}"
+export RENOVATE_NAMESPACE
+
+die() { echo "{\"error\": \"$1\"}"; exit "${2:-1}"; }
+
+ensure_auth() {
+    command -v kubectl >/dev/null 2>&1 || "$_TOOLS_DIR/kubectl/install.sh"
+    command -v tkn >/dev/null 2>&1 || "$_TOOLS_DIR/tkn/install.sh"
+    kubectl auth whoami >/dev/null 2>&1 || die "Not authenticated to the cluster. Run: oc login <cluster-url> or configure kubectl"
+    kubectl get namespace "$RENOVATE_NAMESPACE" >/dev/null 2>&1 || die "Namespace '$RENOVATE_NAMESPACE' not found on the cluster."
+}
+
+# Check if a pipeline has active (non-terminal) TaskRuns.
+# Returns 0 if busy, 1 if idle. Prints JSON either way.
+check_busy() {
+    local pipeline_name="$1"
+    local pipelineruns
+    pipelineruns=$(tkn pipelinerun list -n "$RENOVATE_NAMESPACE" \
+        -o jsonpath='{range .items[*]}{.metadata.labels.tekton\.dev/pipeline}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+        | grep "^${pipeline_name} " | head -10 | cut -d' ' -f2)
+
+    for pr in $pipelineruns; do
+        [ -z "$pr" ] && continue
+        local active
+        active=$(tkn taskrun list -n "$RENOVATE_NAMESPACE" \
+            --label "tekton.dev/pipelineRun=${pr}" \
+            -o jsonpath='{range .items[*]}{.status.conditions[0].reason}{"\n"}{end}' 2>/dev/null \
+            | grep -cvE "^(Succeeded|Failed|TaskRunCancelled|TaskRunTimeout)$" 2>/dev/null || true)
+        active=${active:-0}
+        if [ "$active" -gt 0 ]; then
+            echo "{\"busy\": true, \"pipelinerun\": \"$pr\", \"active_taskruns\": $active}"
+            return 0
+        fi
+    done
+    echo '{"busy": false}'
+    return 1
+}

--- a/claudio-plugin/skills/renovate-pipelinerun/scripts/check_auth.sh
+++ b/claudio-plugin/skills/renovate-pipelinerun/scripts/check_auth.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# Check OpenShift cluster authentication and namespace configuration.
+# Usage: ./check_auth.sh
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+ensure_auth
+
+user=$(kubectl auth whoami -o jsonpath='{.status.userInfo.username}' 2>/dev/null || echo "unknown")
+server=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null || echo "unknown")
+echo "{\"status\": \"authenticated\", \"user\": \"$user\", \"server\": \"$server\", \"namespace\": \"$RENOVATE_NAMESPACE\"}"

--- a/claudio-plugin/skills/renovate-pipelinerun/scripts/get_logs.sh
+++ b/claudio-plugin/skills/renovate-pipelinerun/scripts/get_logs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Retrieve logs from a PipelineRun or TaskRun.
+# Usage: ./get_logs.sh <name> [--lines N]
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+NAME=""
+LINES=200
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --lines) LINES="${2:-200}"; shift 2 ;;
+        -*) die "Unknown option: $1. Usage: get_logs.sh <name> [--lines N]" ;;
+        *)  NAME="$1"; shift ;;
+    esac
+done
+[[ -n "$NAME" ]] || die "Name is required. Usage: get_logs.sh <pipelinerun-or-taskrun-name> [--lines N]"
+
+ensure_auth
+
+# Try pipelinerun logs first, fall back to taskrun logs
+if tkn pipelinerun logs "$NAME" -n "$RENOVATE_NAMESPACE" >/dev/null 2>&1; then
+    echo "--- Logs for PipelineRun: $NAME (last $LINES lines) ---"
+    tkn pipelinerun logs "$NAME" -n "$RENOVATE_NAMESPACE" 2>&1 | tail -n "$LINES"
+elif tkn taskrun logs "$NAME" -n "$RENOVATE_NAMESPACE" >/dev/null 2>&1; then
+    echo "--- Logs for TaskRun: $NAME (last $LINES lines) ---"
+    tkn taskrun logs "$NAME" -n "$RENOVATE_NAMESPACE" 2>&1 | tail -n "$LINES"
+else
+    die "'$NAME' not found as a PipelineRun or TaskRun in namespace '$RENOVATE_NAMESPACE'"
+fi

--- a/claudio-plugin/skills/renovate-pipelinerun/scripts/get_status.sh
+++ b/claudio-plugin/skills/renovate-pipelinerun/scripts/get_status.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Get PipelineRun status or recent history.
+# Usage:
+#   ./get_status.sh <name>              # Status of a PipelineRun or most recent run for a pipeline
+#   ./get_status.sh <name> --history N  # List last N PipelineRuns for a pipeline
+#   ./get_status.sh --all [--history N] # Recent runs across all Renovate pipelines
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+NAME=""
+HISTORY_COUNT=""
+ALL_PIPELINES=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --history) HISTORY_COUNT="${2:-10}"; shift 2 ;;
+        --all) ALL_PIPELINES=true; shift ;;
+        -*) die "Unknown option: $1" ;;
+        *)  NAME="$1"; shift ;;
+    esac
+done
+[[ -n "$NAME" || "$ALL_PIPELINES" = true ]] || die "Name or --all is required. Usage: get_status.sh <name> [--history N] or get_status.sh --all"
+
+ensure_auth
+
+# --- History mode ---
+list_history() {
+    local filter="$1" count="${HISTORY_COUNT:-10}"
+    local raw
+    raw=$(tkn pipelinerun list -n "$RENOVATE_NAMESPACE" --limit "$count" \
+        -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.tekton\.dev/pipeline}{"\t"}{.status.startTime}{"\t"}{.status.completionTime}{"\t"}{.status.conditions[0].reason}{"\n"}{end}' 2>/dev/null)
+
+    if [[ "$filter" = "--all" ]]; then
+        raw=$(echo "$raw" | grep "	renovate-" || true)
+    else
+        raw=$(echo "$raw" | grep "	${filter}	" || true)
+    fi
+
+    echo "$raw" | jq -Rn '[inputs | select(length > 0) | split("\t") | {name:.[0], pipeline:.[1], start_time:.[2], completion_time:(.[3] // "running"), status:(.[4] // "Unknown")}] | {runs:., count:length}'
+}
+
+# --- Detail mode ---
+show_detail() {
+    local pr_name="$1"
+    local pr_json
+    pr_json=$(tkn pipelinerun describe "$pr_name" -n "$RENOVATE_NAMESPACE" -o json 2>/dev/null) || die "PipelineRun '$pr_name' not found"
+
+    echo "$pr_json" | jq '{
+        pipelinerun: .metadata.name,
+        pipeline: .metadata.labels["tekton.dev/pipeline"],
+        start_time: .status.startTime,
+        completion_time: .status.completionTime,
+        status: .status.conditions[0].reason,
+        message: .status.conditions[0].message,
+        tasks: [.status.childReferences[]? | {name: .pipelineTaskName, taskrun: .name}]
+    }'
+}
+
+# --- Route ---
+if [[ -n "$HISTORY_COUNT" || "$ALL_PIPELINES" = true ]]; then
+    if [[ "$ALL_PIPELINES" = true ]]; then
+        list_history "--all"
+    else
+        list_history "$NAME"
+    fi
+elif tkn pipelinerun describe "$NAME" -n "$RENOVATE_NAMESPACE" -o json >/dev/null 2>&1; then
+    show_detail "$NAME"
+else
+    latest=$(tkn pipelinerun list -n "$RENOVATE_NAMESPACE" \
+        -o jsonpath='{range .items[*]}{.metadata.labels.tekton\.dev/pipeline}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+        | grep "^${NAME} " | head -1 | cut -d' ' -f2)
+    [[ -n "$latest" ]] || die "No PipelineRuns found for pipeline '$NAME'"
+    show_detail "$latest"
+fi

--- a/claudio-plugin/skills/renovate-pipelinerun/scripts/list_pipelines.sh
+++ b/claudio-plugin/skills/renovate-pipelinerun/scripts/list_pipelines.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# List available Renovate pipelines in the configured namespace.
+# Usage: ./list_pipelines.sh
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+ensure_auth
+
+tkn pipeline list -n "$RENOVATE_NAMESPACE" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.creationTimestamp}{"\n"}{end}' 2>/dev/null \
+    | grep "^renovate-" | sort \
+    | jq -Rn '[inputs | split("\t") | {name: .[0], created: .[1]}] | {pipelines: ., count: length}'

--- a/claudio-plugin/skills/renovate-pipelinerun/scripts/start_pipeline.sh
+++ b/claudio-plugin/skills/renovate-pipelinerun/scripts/start_pipeline.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Start a Renovate PipelineRun on OpenShift.
+# Usage: ./start_pipeline.sh <pipeline-name> [--force] [--dry-run]
+# Exit codes: 0=started, 1=error, 2=busy
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+PIPELINE_NAME=""
+FORCE=false
+DRY_RUN=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --force) FORCE=true; shift ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        -*) die "Unknown option: $1. Usage: start_pipeline.sh <pipeline-name> [--force] [--dry-run]" ;;
+        *)  PIPELINE_NAME="$1"; shift ;;
+    esac
+done
+[[ -n "$PIPELINE_NAME" ]] || die "Pipeline name is required. Usage: start_pipeline.sh <pipeline-name> [--force] [--dry-run]"
+
+ensure_auth
+
+# Validate pipeline exists (fetch list once)
+available=$(tkn pipeline list -n "$RENOVATE_NAMESPACE" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | tr ' ' '\n' | grep "^renovate-" | sort)
+echo "$available" | grep -qx "$PIPELINE_NAME" || die "Pipeline '$PIPELINE_NAME' not found. Available: $(echo $available | tr ' ' ',')"
+
+# Busy check
+busy_result=$(check_busy "$PIPELINE_NAME") && is_busy=true || is_busy=false
+if [[ "$is_busy" = true && "$FORCE" = false ]]; then
+    echo "$busy_result" | jq --arg p "$PIPELINE_NAME" '. + {error: "Pipeline is busy. Use --force to start anyway.", pipeline: $p}'
+    exit 2
+fi
+
+# Build tkn command
+tkn_args=(pipeline start "$PIPELINE_NAME" -n "$RENOVATE_NAMESPACE"
+    --serviceaccount renovate-admin --use-param-defaults
+    --pipeline-timeout 2h -w name=shared-workspace,emptyDir="")
+[[ "$DRY_RUN" = true ]] && tkn_args+=(--dry-run -o yaml)
+
+output=$(tkn "${tkn_args[@]}" 2>&1)
+
+if [[ "$DRY_RUN" = true ]]; then
+    echo "$output"
+else
+    pipelinerun_name=$(echo "$output" | grep -oP 'PipelineRun started: \K\S+' || true)
+    [[ -n "$pipelinerun_name" ]] || die "Failed to start PipelineRun. Output: $output"
+    echo "{\"status\": \"started\", \"pipeline\": \"$PIPELINE_NAME\", \"pipelinerun\": \"$pipelinerun_name\", \"namespace\": \"$RENOVATE_NAMESPACE\"}"
+fi

--- a/claudio-plugin/tools/tkn/install.sh
+++ b/claudio-plugin/tools/tkn/install.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# tkn (Tekton CLI) Installation Script (Linux Only)
+#
+# This script installs or updates tkn on Linux systems.
+# Supports: x86_64 and ARM64 (aarch64) architectures only.
+#
+# Usage:
+#   ./install.sh                # Check and install tkn
+#   ./install.sh --check        # Only check, don't install
+
+set -euo pipefail
+
+# ============================================================================
+# LOAD COMMON LIBRARY
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../common.sh
+source "$SCRIPT_DIR/../common.sh"
+
+# ============================================================================
+# DEPENDENCY VERSION
+# ============================================================================
+# This version is tracked by Renovate for automatic updates
+# renovate: datasource=github-releases depName=tektoncd/cli
+TKN_VERSION="0.40.0"
+
+# ============================================================================
+# CONFIGURATION
+# ============================================================================
+
+# Determine install directory - prefer /usr/local/bin, fallback to ~/.local/bin
+if [ -z "${INSTALL_DIR:-}" ]; then
+    if [ -w "/usr/local/bin" ]; then
+        INSTALL_DIR="/usr/local/bin"
+    else
+        INSTALL_DIR="$HOME/.local/bin"
+    fi
+fi
+
+# ============================================================================
+# HELPER FUNCTIONS
+# ============================================================================
+
+# Get installed tkn version
+get_tkn_version() {
+    if command_exists tkn; then
+        tkn version 2>/dev/null | grep -oP 'Client version:\s*\K[0-9.]+' || echo "unknown"
+    else
+        echo "not_installed"
+    fi
+}
+
+# ============================================================================
+# TKN INSTALLATION
+# ============================================================================
+
+check_tkn() {
+    local current_version
+
+    if ! command_exists tkn; then
+        log "tkn is not installed"
+        return 1
+    fi
+
+    current_version=$(get_tkn_version)
+    log "tkn version: $current_version"
+
+    if [ "$current_version" = "unknown" ]; then
+        log "Could not determine tkn version"
+        return 0
+    fi
+
+    if version_gte "$current_version" "$TKN_VERSION"; then
+        log "tkn is up to date (>= $TKN_VERSION)"
+        return 0
+    else
+        log "tkn version $current_version is older than required $TKN_VERSION"
+        return 1
+    fi
+}
+
+install_tkn() {
+    local arch
+    arch=$(detect_arch)
+
+    log "Installing tkn v${TKN_VERSION} for Linux $arch..."
+
+    # Verify we're on Linux
+    verify_linux || return 1
+
+    # Ensure install directory exists
+    mkdir -p "$INSTALL_DIR"
+
+    # Map architecture to download name
+    local download_arch
+    if [ "$arch" = "x86_64" ]; then
+        download_arch="x86_64"
+    else
+        download_arch="aarch64"
+    fi
+
+    local tarball="tkn_${TKN_VERSION}_Linux_${download_arch}.tar.gz"
+    local download_url="https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/${tarball}"
+
+    log "Downloading from: $download_url"
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap "rm -rf '$tmp_dir'" EXIT
+
+    curl -fsSL "$download_url" -o "$tmp_dir/$tarball"
+    tar -xzf "$tmp_dir/$tarball" -C "$tmp_dir"
+    mv "$tmp_dir/tkn" "$INSTALL_DIR/tkn"
+    chmod +x "$INSTALL_DIR/tkn"
+
+    # Verify installation
+    if check_tkn; then
+        log "tkn installed successfully"
+        return 0
+    else
+        log "tkn installation verification failed" >&2
+        return 1
+    fi
+}
+
+# ============================================================================
+# MAIN SCRIPT
+# ============================================================================
+
+main() {
+    local check_only=false
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -c|--check)
+                check_only=true
+                shift
+                ;;
+            *)
+                log "ERROR: Unknown option: $1" >&2
+                log "Usage: $(basename "$0") [--check]" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    # Ensure INSTALL_DIR exists
+    mkdir -p "$INSTALL_DIR"
+
+    # Check if INSTALL_DIR is in PATH
+    warn_if_not_in_path "$INSTALL_DIR"
+
+    # Execute based on options
+    if [ "$check_only" = true ]; then
+        check_tkn
+        exit $?
+    fi
+
+    # Install if needed
+    if ! check_tkn; then
+        echo ""
+        log "Installing tkn..."
+        install_tkn
+    fi
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
Automates the manual process of creating PipelineRuns for Renovate execution
with cluster auth validation, pipeline discovery, busy-checking, and status/log monitoring.

Signed-off-by: Giulia Naponiello <gnaponie@redhat.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>