### PR TITLE
feat: add GitHub release workflow on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main or release branch
+        run: |
+          git branch -r --contains ${{ github.sha }} | grep -qE 'origin/main|origin/release-' || \
+            (echo "Tag is not on main or a release branch" && exit 1)
+
+      - name: Extract version from tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ env.VERSION }}" \
+            --title "Release v${{ env.VERSION }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that creates a GitHub Release with auto-generated changelog whenever a `v*.*.*` tag is pushed
- Validates the tag exists on `main` or a `release-*` branch before creating the release

## Test plan
- [ ] Push a test tag (e.g. `v0.2.0`) on main and verify the workflow triggers
- [ ] Verify the GitHub Release is created with generated release notes
- [ ] Verify a tag on a non-main/non-release branch is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated release workflow to streamline the release process. GitHub Releases are now automatically created with generated release notes when version tags are pushed, ensuring consistency and reducing manual release steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->