### PR TITLE
fix(konflux-release): require actual Konflux component names and immutable output files

### DIFF
--- a/claudio-plugin/skills/konflux-release/SKILL.md
+++ b/claudio-plugin/skills/konflux-release/SKILL.md
@@ -40,7 +40,7 @@ This skill includes helper scripts in `scripts/` directory.
 
 **Correct execution:**
 ```bash
-/full/path/to/konflux-release/scripts/generate_release_yaml.py --component foo --version 1.0 --snapshot bar --release-plan prod --release-name foo-1-0-prod-1 --accelerator Variant --namespace ns --release-notes-template /path/to/template.yaml --release-type RHEA --output /path/to/out/foo.yaml
+/full/path/to/konflux-release/scripts/generate_release_yaml.py --version 1.0 --snapshot bar --release-plan prod --release-name foo-1-0-prod-1 --accelerator Variant --namespace ns --release-notes-template /path/to/template.yaml --release-type RHEA --output /path/to/out/foo-prod-1.yaml
 ```
 
 **Incorrect execution:**
@@ -138,6 +138,8 @@ For each successful stage release, extract:
 - **Snapshot name:** `.spec.snapshot`
 - **Stage ReleasePlan:** `.spec.releasePlan`
 
+**Component names must come from the cluster.** Always use the actual Konflux component name from the `appstudio.openshift.io/component` label — never construct or guess component names. Konflux components use **branch-based** suffixes (e.g., `-3-3` for branch `3.3`), not release version suffixes (e.g., `-3-3-1` for version `3.3.1`). Z-stream releases like `3.3.1` reuse the same components as `3.3.0`.
+
 Then determine:
 
 - **Tech preview status** - from product config or user input
@@ -176,11 +178,10 @@ kubectl get releases -n <namespace> -o json | jq '[.items[] | select(.spec.relea
 The script automatically creates the output directory. Use the provided script for each component (full path, single line):
 
 ```bash
-/full/path/to/konflux-release/scripts/generate_release_yaml.py --component <component-name> --version <version> --snapshot <snapshot-name> --release-plan <prod-release-plan> --release-name <release-name> --accelerator <accelerator> --namespace <namespace> --release-notes-template <template-path> --release-type <RHEA|RHSA> --output /path/to/output/<component>-prod.yaml
+/full/path/to/konflux-release/scripts/generate_release_yaml.py --version <version> --snapshot <snapshot-name> --release-plan <prod-release-plan> --release-name <release-name> --accelerator <accelerator> --namespace <namespace> --release-notes-template <template-path> --release-type <RHEA|RHSA> --output /path/to/output/<component>-prod-<seq>.yaml
 ```
 
 **Required parameters:**
-- `--component` - component name
 - `--version` - semantic version
 - `--snapshot` - snapshot name from the successful stage release
 - `--release-plan` - production release plan name
@@ -189,10 +190,14 @@ The script automatically creates the output directory. Use the provided script f
 - `--namespace` - Kubernetes namespace
 - `--release-notes-template` - path to release notes YAML template
 - `--release-type` - RHEA (default) or RHSA
-- `--output` - output file path
+- `--output` - output file path (must include sequence number — see Output File Naming below)
+
+**RHSA parameters (required when `--release-type RHSA`):**
+- `--cves-file` - path to CVE list file
+- `--component` - single actual Konflux component name for CVE entries, OR
+- `--cve-components` - comma-separated list of actual Konflux component names (for full-application releases with multiple components per Release CR)
 
 **Optional parameters:**
-- `--cves-file` - path to CVE list file (required for RHSA releases)
 - `--grace-period` - grace period in days (default: 30)
 
 ### Step 8: Generate Release Summary
@@ -262,11 +267,26 @@ The script replaces all placeholders recursively through all string values.
 ### Release Types
 
 - **RHEA** (default) - Enhancement Advisory, standard feature releases
-- **RHSA** - Security Advisory, requires `--cves-file` and `--component` parameters
-  - The script auto-constructs the versioned CVE component name from `--component` and `--version` (e.g., `my-component` + `3.2.2` → `my-component-3-2-2`)
+- **RHSA** - Security Advisory, requires `--cves-file` and either `--component` (single) or `--cve-components` (multiple)
+  - **CVE component names must be actual Konflux component names** from the snapshot — never construct or guess them. Query the snapshot to get the real component names (see "RHSA Component Names" below)
   - CVE file format: one CVE per line (CVE-YYYY-NNNNN)
   - Comments starting with # are ignored
   - Empty lines are skipped
+
+#### RHSA Component Names
+
+For RHSA releases, each CVE entry requires a `component` field. This must be the **actual Konflux component name** as it exists in the cluster — the same name that appears in the `appstudio.openshift.io/component` label on releases and in the snapshot's component list.
+
+**How to get real component names from a snapshot:**
+```bash
+kubectl get snapshot <snapshot-name> -n <namespace> -o json | jq -r '.spec.components[].name'
+```
+
+**For single-component releases:** pass the Konflux component name directly as `--component` (e.g., `--component rhaiis-cuda-ubi9-3-4`).
+
+**For full-application releases (e.g., rhelai):** the snapshot contains many components. Each CVE must be paired with each affected component. Extract all component names from the snapshot and pass them as a comma-separated list to `--cve-components` (e.g., `--cve-components bootc-cuda-3-3,bootc-rocm-3-3,bootc-cuda-aws-3-3`). This generates one CVE entry per CVE × component combination.
+
+**Common mistake:** do NOT construct component names by appending the release version (e.g., `bootc-cuda-3-3-1`). Konflux components use branch-based suffixes (`-3-3`), not release version suffixes (`-3-3-1`). A z-stream release like `3.3.1` uses the same `-3-3` components as `3.3.0`.
 
 ## Release Summary
 
@@ -294,8 +314,8 @@ The script replaces all placeholders recursively through all string values.
 | Source | <repository-url> |
 
 ### Generated Files
-- component-1-prod.yaml
-- component-2-prod.yaml
+- component-1-prod-1.yaml
+- component-2-prod-1.yaml
 ```
 
 - **Stage Image** — the timestamped image URL extracted from `.status.artifacts.images[].urls[]` (see Step 5b)
@@ -342,6 +362,16 @@ Pattern: `<release-plan-name>-<seq>`
 
 - `<release-plan-name>` - the target release plan name
 - `<seq>` - sequence number (auto-incremented per release plan, starting from 1)
+
+### Output File Naming
+
+Output YAML filenames MUST include the sequence number to prevent overwriting previous releases:
+
+Pattern: `<base-component>-<release-type>-<seq>.yaml`
+
+Examples: `my-comp-cuda-prod-1.yaml`, `my-comp-cuda-stage-rc-2.yaml`
+
+**Never overwrite existing release files.** Each Release CR YAML is an immutable record of a release. When generating a new release for a component that already has release files, always create a new file with the next sequence number — never reuse or overwrite an existing filename.
 
 ### ReleasePlan Types
 

--- a/claudio-plugin/skills/konflux-release/scripts/generate_release_yaml.py
+++ b/claudio-plugin/skills/konflux-release/scripts/generate_release_yaml.py
@@ -16,10 +16,11 @@ Usage:
                              --release-notes-template /tmp/ga-rhea.yaml \\
                              --release-type RHSA \\
                              --cves-file cves \\
-                             --output out/my-product-cuda-ubi9-3.2.5-prod.yaml
+                             --output out/my-product-cuda-ubi9-prod-4.yaml
 
 Arguments:
-    --component NAME              Component name (required for RHSA with --cves-file)
+    --component NAME              Single Konflux component name for CVE entries
+    --cve-components NAMES        Comma-separated Konflux component names for CVE entries
     --version VERSION             Semantic version (e.g., 3.2.5) (required)
     --snapshot NAME               Snapshot name (required)
     --release-plan NAME           Release plan name (required)
@@ -123,7 +124,7 @@ def apply_template_substitutions(template, version, accelerator):
 
 def generate_prod_release_yaml(component_name, version, snapshot, release_plan,
                                release_name, accelerator, namespace, release_notes_template,
-                               release_type, cves_file, grace_period):
+                               release_type, cves_file, grace_period, cve_components=None):
     """
     Generate production release YAML.
 
@@ -139,6 +140,7 @@ def generate_prod_release_yaml(component_name, version, snapshot, release_plan,
         release_type: "RHEA" or "RHSA"
         cves_file: Path to CVE file (optional)
         grace_period: Grace period in days
+        cve_components: Comma-separated Konflux component names for CVE entries (optional)
 
     Returns:
         dict: Production release YAML structure
@@ -156,9 +158,14 @@ def generate_prod_release_yaml(component_name, version, snapshot, release_plan,
     # Add CVEs for RHSA if file provided
     if release_type == 'RHSA' and cves_file:
         cve_ids = load_cves_from_file(cves_file)
-        # Build CVE list with component name
-        versioned_component = f"{component_name}-{version.replace('.', '-')}"
-        release_notes['cves'] = [{'key': cve_id, 'component': versioned_component} for cve_id in cve_ids]
+        if cve_components:
+            components = [c.strip() for c in cve_components.split(',') if c.strip()]
+        elif component_name:
+            components = [component_name]
+        else:
+            components = []
+        release_notes['cves'] = [{'key': cve_id, 'component': comp}
+                                 for cve_id in cve_ids for comp in components]
 
     # Build production release YAML
     prod_release = {
@@ -209,6 +216,8 @@ def main():
                        help='Release type (default: RHEA)')
     parser.add_argument('--cves-file', type=str,
                        help='Path to CVE list file (optional, for RHSA)')
+    parser.add_argument('--cve-components', type=str,
+                       help='Comma-separated actual Konflux component names for CVE entries (e.g., bootc-cuda-3-3,bootc-rocm-3-3)')
     parser.add_argument('--grace-period', type=int, default=30,
                        help='Grace period in days (default: 30)')
     parser.add_argument('--output', type=str,
@@ -216,8 +225,8 @@ def main():
 
     args = parser.parse_args()
 
-    if args.release_type == 'RHSA' and args.cves_file and args.component is None:
-        print("Error: --component is required for RHSA releases with a CVE file", file=sys.stderr)
+    if args.release_type == 'RHSA' and args.cves_file and args.component is None and args.cve_components is None:
+        print("Error: --component or --cve-components is required for RHSA releases with a CVE file", file=sys.stderr)
         sys.exit(1)
 
     # Load release notes template
@@ -235,7 +244,8 @@ def main():
         release_notes_template,
         args.release_type,
         args.cves_file,
-        args.grace_period
+        args.grace_period,
+        args.cve_components
     )
 
     # Convert to YAML string

--- a/claudio-plugin/skills/konflux-release/tests/test_generate_release_yaml.py
+++ b/claudio-plugin/skills/konflux-release/tests/test_generate_release_yaml.py
@@ -118,6 +118,7 @@ class TestGenerateProdReleaseYaml:
             release_type="RHEA",
             cves_file=None,
             grace_period=30,
+            cve_components=None,
         )
         defaults.update(overrides)
         return generate_prod_release_yaml(**defaults)
@@ -146,8 +147,60 @@ class TestGenerateProdReleaseYaml:
         cve_file.write_text("CVE-2024-1234\nCVE-2024-5678\n")
         cves = self._call(release_type="RHSA", cves_file=str(cve_file))["spec"]["data"]["releaseNotes"]["cves"]
         assert cves == [
-            {"key": "CVE-2024-1234", "component": "my-comp-3-3-0"},
-            {"key": "CVE-2024-5678", "component": "my-comp-3-3-0"},
+            {"key": "CVE-2024-1234", "component": "my-comp"},
+            {"key": "CVE-2024-5678", "component": "my-comp"},
+        ]
+
+    def test_rhsa_with_cve_components(self, tmp_path):
+        cve_file = tmp_path / "cves.txt"
+        cve_file.write_text("CVE-2024-1234\n")
+        cves = self._call(
+            release_type="RHSA",
+            cves_file=str(cve_file),
+            cve_components="bootc-cuda-3-3,bootc-rocm-3-3",
+        )["spec"]["data"]["releaseNotes"]["cves"]
+        assert cves == [
+            {"key": "CVE-2024-1234", "component": "bootc-cuda-3-3"},
+            {"key": "CVE-2024-1234", "component": "bootc-rocm-3-3"},
+        ]
+
+    def test_rhsa_cve_components_override_component_name(self, tmp_path):
+        cve_file = tmp_path / "cves.txt"
+        cve_file.write_text("CVE-2024-9999\n")
+        cves = self._call(
+            component_name="ignored-comp",
+            release_type="RHSA",
+            cves_file=str(cve_file),
+            cve_components="actual-comp-3-3",
+        )["spec"]["data"]["releaseNotes"]["cves"]
+        assert cves == [{"key": "CVE-2024-9999", "component": "actual-comp-3-3"}]
+
+    def test_rhsa_cve_components_filters_empty(self, tmp_path):
+        cve_file = tmp_path / "cves.txt"
+        cve_file.write_text("CVE-2024-1234\n")
+        cves = self._call(
+            release_type="RHSA",
+            cves_file=str(cve_file),
+            cve_components="comp-a,,comp-b, ,",
+        )["spec"]["data"]["releaseNotes"]["cves"]
+        assert cves == [
+            {"key": "CVE-2024-1234", "component": "comp-a"},
+            {"key": "CVE-2024-1234", "component": "comp-b"},
+        ]
+
+    def test_rhsa_multi_cves_multi_components(self, tmp_path):
+        cve_file = tmp_path / "cves.txt"
+        cve_file.write_text("CVE-2024-1111\nCVE-2024-2222\n")
+        cves = self._call(
+            release_type="RHSA",
+            cves_file=str(cve_file),
+            cve_components="comp-a,comp-b",
+        )["spec"]["data"]["releaseNotes"]["cves"]
+        assert cves == [
+            {"key": "CVE-2024-1111", "component": "comp-a"},
+            {"key": "CVE-2024-1111", "component": "comp-b"},
+            {"key": "CVE-2024-2222", "component": "comp-a"},
+            {"key": "CVE-2024-2222", "component": "comp-b"},
         ]
 
     def test_template_substitution_applied(self):
@@ -228,6 +281,22 @@ class TestMain:
         with pytest.raises(SystemExit) as exc:
             main()
         assert exc.value.code != 0
+
+    def test_rhsa_with_cve_components_cli(self, tmp_path, monkeypatch, capsys):
+        cve_file = tmp_path / "cves.txt"
+        cve_file.write_text("CVE-2024-1234\n")
+        argv = self._base_argv(tmp_path) + [
+            "--release-type", "RHSA",
+            "--cves-file", str(cve_file),
+            "--cve-components", "bootc-cuda-3-3,bootc-rocm-3-3",
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+        main()
+        cves = yaml.safe_load(capsys.readouterr().out)["spec"]["data"]["releaseNotes"]["cves"]
+        assert cves == [
+            {"key": "CVE-2024-1234", "component": "bootc-cuda-3-3"},
+            {"key": "CVE-2024-1234", "component": "bootc-rocm-3-3"},
+        ]
 
     def test_missing_required_arg_fails(self, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["prog", "--version", "3.3.0"])


### PR DESCRIPTION
## Summary

- Add `--cve-components` flag to `generate_release_yaml.py` for passing actual Konflux component names
- Remove auto-versioned component name construction (e.g. `my-comp-3-3-0`) — use real names from the cluster
- Enforce immutable release output files — never overwrite existing YAMLs, use incremented sequence numbers
- Update SKILL.md with `--cve-components` docs, immutability rules, branch-based naming, and CVE handling
- Fix existing RHSA test and add 5 new tests for `--cve-components` (single, multi, override, cross-product, CLI)

## Context

During a 3.3.1 z-stream RHSA release, the skill hallucinated `-3-3-1` component names when the actual Konflux components were `-3-3` (branch-based). It also overwrote existing release YAML files instead of creating new ones with incremented sequence numbers.

See MR comparison:
- Wrong: https://gitlab.com/redhat/rhel-ai/ci-cd/aipcc-product-management-configs/-/merge_requests/202
- Correct: https://gitlab.com/redhat/rhel-ai/ci-cd/aipcc-product-management-configs/-/merge_requests/203

## Test plan

- [ ] Verify SKILL.md renders correctly
- [ ] Test with a stage-rc or prod release to confirm component names are queried from cluster
- [ ] Test RHSA release to confirm per-component CVE entries
- [x] Unit tests pass (33/33, including 5 new `--cve-components` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Jakub Rusz <jrusz@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added option to specify multiple components for CVE/RHSA entries when generating release YAMLs.

* **Improvements**
  * Output filenames now require sequence-numbered names to avoid overwrites.
  * Documentation clarifies how to extract real component names from cluster snapshots and favors branch-based suffixing.
  * CLI validation updated: `--component` is no longer universally required for generation when multiple CVE components are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->