### PR TITLE
chore: add test requirements tracking, skopeo version pinning and update Renovate config for schedule

### DIFF
--- a/claudio-plugin/tools/skopeo/install.sh
+++ b/claudio-plugin/tools/skopeo/install.sh
@@ -20,6 +20,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../common.sh"
 
 # ============================================================================
+# DEPENDENCY VERSION
+# ============================================================================
+# Skopeo is primarily installed in the claudio container (ubi10) via microdnf;
+# this script is a fallback for environments where skopeo is not pre-installed.
+# renovate: datasource=repology depName=centos_stream_10/skopeo versioning=loose
+SKOPEO_VERSION="1.20.0"
+
+# ============================================================================
 # SKOPEO INSTALLATION
 # ============================================================================
 
@@ -51,7 +59,7 @@ install_skopeo() {
     local pkg_manager
     pkg_manager=$(detect_package_manager)
 
-    log "Installing skopeo using package manager: $pkg_manager"
+    log "Installing skopeo ${SKOPEO_VERSION} using package manager: $pkg_manager"
 
     # Verify we're on Linux
     verify_linux || return 1
@@ -59,7 +67,7 @@ install_skopeo() {
     case "$pkg_manager" in
         dnf)
             log "Installing skopeo via dnf..."
-            if maybe_sudo dnf install -y skopeo; then
+            if maybe_sudo dnf install -y "skopeo-${SKOPEO_VERSION}" 2>/dev/null || maybe_sudo dnf install -y skopeo; then
                 log "✓ skopeo installed successfully via dnf"
             else
                 log "✗ Failed to install skopeo via dnf" >&2
@@ -69,7 +77,7 @@ install_skopeo() {
             ;;
         apt)
             log "Installing skopeo via apt..."
-            if maybe_sudo apt-get update && maybe_sudo apt-get install -y skopeo; then
+            if maybe_sudo apt-get update && { maybe_sudo apt-get install -y "skopeo=${SKOPEO_VERSION}*" 2>/dev/null || maybe_sudo apt-get install -y skopeo; }; then
                 log "✓ skopeo installed successfully via apt"
             else
                 log "✗ Failed to install skopeo via apt" >&2
@@ -79,7 +87,7 @@ install_skopeo() {
             ;;
         apk)
             log "Installing skopeo via apk..."
-            if maybe_sudo apk add skopeo; then
+            if maybe_sudo apk add "skopeo~=${SKOPEO_VERSION}" 2>/dev/null || maybe_sudo apk add skopeo; then
                 log "✓ skopeo installed successfully via apk"
             else
                 log "✗ Failed to install skopeo via apk" >&2

--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "group:all"
+    "group:all",
+    "schedule:weekly"
   ],
   "baseBranchPatterns": [
     "main"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["pip_requirements"],
+      "rangeStrategy": "bump"
+    }
   ],
   "customManagers": [
     {
@@ -19,6 +26,17 @@
       ],
       "versioningTemplate": "semver",
       "extractVersionTemplate": "^(?:v|jq-)?(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Update system package versions via repology",
+      "managerFilePatterns": [
+        "/^claudio-plugin/tools/.+/install\\.sh$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\s+versioning=(?<versioning>[^\\s]+)\\n[A-Z_]+_VERSION=\"(?<currentValue>[^\"]+)\""
+      ],
+      "extractVersionTemplate": "^(?:\\d+:)?(?<version>[0-9]+\\.[0-9]+\\.[0-9]+)"
     }
   ]
 }


### PR DESCRIPTION
Jira https://redhat.atlassian.net/browse/AIPCC-13775 

## Summary

- Add Renovate tracking for pip dependencies (`requirements.txt` and `requirements-test.txt`) across all skills by setting `rangeStrategy: "bump"` — fixes the issue where `>=` constraints were never updated because new versions satisfied the existing range
- Add Renovate tracking for skopeo via the `repology` datasource (`centos_stream_10/skopeo`), with version-pinned install attempts and fallback to unpinned install
- Add a separate custom regex manager for repology-tracked system packages with `loose` versioning and an `extractVersionTemplate` that strips RPM epoch/release suffixes
- Reduce Renovate scan frequency to weekly (`schedule:weekly`) to lower resource costs

## Test Plan

- [x] Renovate dry run confirms all 5 requirements files detected with pip version bumps (pytest, PyYAML, requests, responses)
- [x] Renovate dry run confirms skopeo detected via repology with clean version (`1.22.2`, not `2:1.22.2-2.el10`)
- [x] No duplicate dependency extraction between the two custom managers
- [x] `schedule:weekly` correctly gates PR creation to Monday 0-3am UTC
- [x] Shell syntax check passes (`bash -n`)
- [x] All 102 existing tests pass (gitlab-branch-manager, konflux-release, slack-utilities)
- [x] Dry run PR: https://github.com/srija-ganguly/claudio-skills/pull/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned skopeo to version 1.20.0 with fallback installation mechanism
  * Updated dependency update schedule to run weekly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->