### PR TITLE
feat(pmc-discovery): add Python requirements for runtime install

### DIFF
--- a/claudio-plugin/tools/python/pmc-discovery-requirements.txt
+++ b/claudio-plugin/tools/python/pmc-discovery-requirements.txt
@@ -1,0 +1,4 @@
+# Dependencies for PMC Discovery skill (pmc_sync.py)
+
+PyYAML>=6.0
+ruamel.yaml>=0.18


### PR DESCRIPTION
## Summary

Adds `pmc-discovery-requirements.txt` to `claudio-plugin/tools/python/` so the PMC Discovery skill's Python deps (PyYAML, ruamel.yaml) get installed at runtime via the existing `install.sh` mechanism.

Related: https://gitlab.com/redhat/rhel-ai/ci-cd/aipcc-claudio/-/merge_requests/49

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python dependencies to ensure system compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->