### PR TITLE
AIPCC-15096: Add cloud disk image upload PipelineRun generation to konflux-release skill

### DIFF
--- a/claudio-plugin/skills/konflux-release/SKILL.md
+++ b/claudio-plugin/skills/konflux-release/SKILL.md
@@ -224,12 +224,12 @@ sed -e 's/{{ACCELERATOR}}/cuda/g' -e 's/{{CLOUD_PROVIDER}}/aws/g' -e 's|{{CONTAI
 |---|---|
 | `ACCELERATOR` | Parsed from the component name (e.g., `bootc-cuda-aws-disk-image` → `cuda`) |
 | `CLOUD_PROVIDER` | Parsed from the component name (e.g., `bootc-cuda-aws-disk-image` → `aws`) |
-| `CONTAINER_IMAGE` | From the release snapshot: `kubectl get snapshot <name> -n <ns> -o json \| jq -r '.spec.components[] \| select(.name == "<component>") \| .containerImage'` |
+| `CONTAINER_IMAGE` | Digest-pinned OCI reference from the release snapshot (e.g., `quay.io/...@sha256:...`). Must include the `@sha256:` digest, not a tag. Extract via: `kubectl get snapshot <name> -n <ns> -o json \| jq -r '.spec.components[] \| select(.name == "<component>") \| .containerImage'` |
 | `PULL_SECRET_NAME` | From `config-disk-images.yaml` or derived from application/branch (e.g., `rhelai-bootc-3-3-pull`) |
 | `RHEL_AI_VERSION` | The release version provided by the user (e.g., `3.3.0`) |
 | `NAMESPACE` | From `config-disk-images.yaml` field `definitions[].tenant` (e.g., `rhel-ai-tenant`) |
 
-**Output files:** One PipelineRun YAML per cloud disk image component, named `upload-rhel-ai-<accelerator>-<cloud>-disk-image.yaml`. These files are committed to `konflux-data/pipelineruns/` (see Step 9).
+**Output files:** One PipelineRun YAML per cloud disk image component, named `upload-rhel-ai-<accelerator>-<cloud>-disk-image.yaml`. These files are written to the same release version directory as the Release CRs (e.g., `rhelai/<branch>/releases/<version>/`).
 
 ### Step 8: Generate Release Summary
 
@@ -247,19 +247,6 @@ The generated release YAMLs and summary are NOT applied directly to the cluster.
 **Config-driven mode:** Follow the config repo's CLAUDE.md instructions for where to store output files. Commit the generated files and open a merge request against the config repo for human review.
 
 **Manual mode:** Write the files to a local output directory. The user decides how to apply them (manually, via CI, etc.).
-
-**Cloud image upload PipelineRuns (when generated in Step 7b):**
-
-If PipelineRun YAMLs were generated, commit them to the `konflux-data` repository:
-
-1. The `konflux-data` repo must be available locally as a working directory
-2. Create a branch using the release's JIRA ticket following the same naming convention as `aipcc-product-management-configs` (e.g., `AIPCC-XXXXX-upload-disk-images-<version>`)
-3. Write the PipelineRun YAMLs to `konflux-data/pipelineruns/`
-4. Commit and open a merge request in `konflux-data` for review
-
-This results in two MRs per release when cloud disk images are involved:
-- Release CRs + RELEASE_SUMMARY.md → MR in `aipcc-product-management-configs`
-- PipelineRun YAMLs → MR in `konflux-data`
 
 ## Config-Driven Mode
 

--- a/claudio-plugin/skills/konflux-release/SKILL.md
+++ b/claudio-plugin/skills/konflux-release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: konflux-release
 description: Create production releases on the Konflux platform. Handles the complete stage-to-production release workflow including discovering stage releases, generating production release YAMLs with release notes, and preparing them for review. Supports manual mode and config-driven mode with an external product config directory.
-allowed-tools: Bash(*/konflux-release/scripts/generate_release_yaml.py *),Bash(kubectl get *),Bash(skopeo inspect *),Bash(glab api --method GET *),Write(*RELEASE_SUMMARY*)
+allowed-tools: Bash(*/konflux-release/scripts/generate_release_yaml.py *),Bash(kubectl get *),Bash(skopeo inspect *),Bash(glab api --method GET *),Write(*RELEASE_SUMMARY*),Bash(sed *upload-rhel-ai-disk-image-pipelinerun.yaml*)
 ---
 
 # Konflux Release
@@ -200,6 +200,37 @@ The script automatically creates the output directory. Use the provided script f
 **Optional parameters:**
 - `--grace-period` - grace period in days (default: 30)
 
+### Step 7b: Generate Cloud Image Upload PipelineRuns
+
+When releasing disk image components for rhelai, also generate PipelineRun YAMLs for uploading cloud disk images. The following component-to-cloud mappings are supported:
+
+| Component pattern | Accelerator | Cloud Provider |
+|---|---|---|
+| `bootc-cuda-aws-disk-image` | cuda | aws |
+| `bootc-cuda-azure-disk-image` | cuda | azure |
+| `bootc-rocm-azure-disk-image` | rocm | azure |
+
+**When to generate:** During both full releases and single-component releases, if the release includes any of the above cloud disk image components.
+
+**How to generate:** Use the PipelineRun YAML template at `templates/upload-rhel-ai-disk-image-pipelinerun.yaml` and substitute the placeholder variables using `sed`:
+
+```bash
+sed -e 's/{{ACCELERATOR}}/cuda/g' -e 's/{{CLOUD_PROVIDER}}/aws/g' -e 's|{{CONTAINER_IMAGE}}|<image-ref>|g' -e 's/{{PULL_SECRET_NAME}}/<pull-secret>/g' -e 's/{{RHEL_AI_VERSION}}/<version>/g' -e 's/{{NAMESPACE}}/<namespace>/g' /full/path/to/konflux-release/templates/upload-rhel-ai-disk-image-pipelinerun.yaml > /path/to/output/upload-rhel-ai-cuda-aws-disk-image.yaml
+```
+
+**Variable sources:**
+
+| Variable | Source |
+|---|---|
+| `ACCELERATOR` | Parsed from the component name (e.g., `bootc-cuda-aws-disk-image` → `cuda`) |
+| `CLOUD_PROVIDER` | Parsed from the component name (e.g., `bootc-cuda-aws-disk-image` → `aws`) |
+| `CONTAINER_IMAGE` | From the release snapshot: `kubectl get snapshot <name> -n <ns> -o json \| jq -r '.spec.components[] \| select(.name == "<component>") \| .containerImage'` |
+| `PULL_SECRET_NAME` | From `config-disk-images.yaml` or derived from application/branch (e.g., `rhelai-bootc-3-3-pull`) |
+| `RHEL_AI_VERSION` | The release version provided by the user (e.g., `3.3.0`) |
+| `NAMESPACE` | From `config-disk-images.yaml` field `definitions[].tenant` (e.g., `rhel-ai-tenant`) |
+
+**Output files:** One PipelineRun YAML per cloud disk image component, named `upload-rhel-ai-<accelerator>-<cloud>-disk-image.yaml`. These files are committed to `konflux-data/pipelineruns/` (see Step 9).
+
 ### Step 8: Generate Release Summary
 
 Create a summary document that includes:
@@ -216,6 +247,19 @@ The generated release YAMLs and summary are NOT applied directly to the cluster.
 **Config-driven mode:** Follow the config repo's CLAUDE.md instructions for where to store output files. Commit the generated files and open a merge request against the config repo for human review.
 
 **Manual mode:** Write the files to a local output directory. The user decides how to apply them (manually, via CI, etc.).
+
+**Cloud image upload PipelineRuns (when generated in Step 7b):**
+
+If PipelineRun YAMLs were generated, commit them to the `konflux-data` repository:
+
+1. The `konflux-data` repo must be available locally as a working directory
+2. Create a branch using the release's JIRA ticket following the same naming convention as `aipcc-product-management-configs` (e.g., `AIPCC-XXXXX-upload-disk-images-<version>`)
+3. Write the PipelineRun YAMLs to `konflux-data/pipelineruns/`
+4. Commit and open a merge request in `konflux-data` for review
+
+This results in two MRs per release when cloud disk images are involved:
+- Release CRs + RELEASE_SUMMARY.md → MR in `aipcc-product-management-configs`
+- PipelineRun YAMLs → MR in `konflux-data`
 
 ## Config-Driven Mode
 

--- a/claudio-plugin/skills/konflux-release/templates/upload-rhel-ai-disk-image-pipelinerun.yaml
+++ b/claudio-plugin/skills/konflux-release/templates/upload-rhel-ai-disk-image-pipelinerun.yaml
@@ -5,18 +5,24 @@ metadata:
   namespace: {{NAMESPACE}}
 spec:
   params:
+    # Accelerator type (cuda, rocm)
     - name: accelerator
       value: "{{ACCELERATOR}}"
+    # Target cloud provider (aws, azure)
     - name: cloud-provider
       value: "{{CLOUD_PROVIDER}}"
+    # Container image URL - must be the digest-pinned OCI reference from the release snapshot (e.g., quay.io/...@sha256:...)
     - name: container-image
       value: "{{CONTAINER_IMAGE}}"
-    - name: pull-secret-name
-      value: "{{PULL_SECRET_NAME}}"
-    - name: rhel-ai-version
-      value: "{{RHEL_AI_VERSION}}"
+    # Debug mode (optional)
     - name: debug
       value: "false"
+    # Pull secret name - unique per Konflux application
+    - name: pull-secret-name
+      value: "{{PULL_SECRET_NAME}}"
+    # RHEL AI version - numeric version only (e.g., 3.3.0). The pipeline constructs the full image name.
+    - name: rhel-ai-version
+      value: "{{RHEL_AI_VERSION}}"
   pipelineRef:
     resolver: git
     params:

--- a/claudio-plugin/skills/konflux-release/templates/upload-rhel-ai-disk-image-pipelinerun.yaml
+++ b/claudio-plugin/skills/konflux-release/templates/upload-rhel-ai-disk-image-pipelinerun.yaml
@@ -1,0 +1,44 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: upload-rhel-ai-{{ACCELERATOR}}-{{CLOUD_PROVIDER}}-disk-image-
+  namespace: {{NAMESPACE}}
+spec:
+  params:
+    - name: accelerator
+      value: "{{ACCELERATOR}}"
+    - name: cloud-provider
+      value: "{{CLOUD_PROVIDER}}"
+    - name: container-image
+      value: "{{CONTAINER_IMAGE}}"
+    - name: pull-secret-name
+      value: "{{PULL_SECRET_NAME}}"
+    - name: rhel-ai-version
+      value: "{{RHEL_AI_VERSION}}"
+    - name: debug
+      value: "false"
+  pipelineRef:
+    resolver: git
+    params:
+      - name: org
+        value: redhat
+      - name: repo
+        value: rhel-ai/konflux-data
+      - name: scmType
+        value: gitlab
+      - name: serverURL
+        value: https://gitlab.com
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/upload-rhel-ai-disk-image.yaml
+      - name: token
+        value: pipelines-as-code-secret
+      - name: tokenKey
+        value: password
+  taskRunTemplate:
+    serviceAccountName: konflux-integration-runner
+  timeouts:
+    pipeline: 3h0m0s
+    tasks: 2h0m0s
+    finally: 1h0m0s


### PR DESCRIPTION
<h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Extends the <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">konflux-release</code> skill to generate Tekton PipelineRun YAMLs for uploading RHEL AI disk images to cloud providers during a release. A single reusable YAML template produces all 3 variants:</p>
Accelerator | Cloud Provider | Component
-- | -- | --
cuda | aws | bootc-cuda-aws-disk-image
cuda | azure | bootc-cuda-azure-disk-image
rocm | azure | bootc-rocm-azure-disk-image

<h3 style="color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h3><ul style="padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong>New PipelineRun YAML template</strong><span> </span>(<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">templates/upload-rhel-ai-disk-image-pipelinerun.yaml</code>) — parameterized template with placeholder variables (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">{{ACCELERATOR}}</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">{{CLOUD_PROVIDER}}</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">{{CONTAINER_IMAGE}}</code>, etc.), substituted via<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">sed</code><span> </span>at release time. Parameters sorted alphabetically, container-image requires digest-pinned<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@sha256:</code><span> </span>reference from the snapshot.</li><li><strong>SKILL.md — Step 7b</strong><span> </span>— new workflow step for generating PipelineRun YAMLs during both full and single-component disk image releases, with a variable source mapping table</li><li><strong>SKILL.md — Step 9</strong><span> </span>— PipelineRun YAMLs are saved alongside Release CRs in the PMC release version directory (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">rhelai/&lt;branch&gt;/releases/&lt;version&gt;/</code>), included in the same MR</li></ul>