### PR TITLE
feat(mapt-provisioner): add mapt provisioner skill and tool installer

### DIFF
--- a/claudio-plugin/skills/mapt-provisioner/SKILL.md
+++ b/claudio-plugin/skills/mapt-provisioner/SKILL.md
@@ -23,8 +23,19 @@ Users will ask in natural language — extract the intent and map it to script f
 | "tag it X=Y" / "tags X=Y,A=B" | `--tags X=Y,A=B` |
 | "store state in s3://..." / "backend s3://..." | set `MAPT_BACKEND_URL=s3://...` |
 | "destroy it" / "tear it down" / "clean up" | `destroy.sh` |
+| "what versions are available?" / "list images" | `get_azure_rhelai_version.sh --list` |
 | "check status" / "is it up?" | `check_status.sh` |
 | "connect to it" / "SSH in" / "run X on it" | SSH directly using conn-details |
+
+**Version normalization:** Users often omit the patch version or use spaces/wrong separators. Normalize before passing `--version`:
+| User says | Normalized |
+|-----------|------------|
+| "3.4 ea1" / "3.4-ea1" / "3.4 ea.1" | `3.4.0-ea.1` |
+| "3.4 ea2" / "3.4-ea2" | `3.4.0-ea.2` |
+| "3.4" / "3.4.0" | `3.4.0` |
+| "3.3.1" | `3.3.1` (already correct) |
+
+The pattern is `MAJOR.MINOR.PATCH` with optional `-ea.N` suffix. If the user omits `.PATCH`, assume `.0`. If they write `ea` without a dot before the number, add it.
 
 **Env var defaults:** `AWS_DEFAULT_REGION` and credentials should be pre-configured in the environment — do not ask the user to provide them in their request. If `MAPT_BACKEND_URL` is already set in the environment, the user does not need to mention it either.
 
@@ -72,7 +83,7 @@ OpenShift SNC is AWS only — mapt does not support Azure for SNC.
 | `--gpus` | Number of GPUs |
 | `--accelerator` | GPU type: `cuda` or `rocm` (mapt default: cuda) |
 | `--spot` | Use spot instances (cheaper, can be interrupted) |
-| `--spot-eviction-tolerance` | Spot tolerance: `lowest`, `low`, `medium`, `high`, `highest` (default: `lowest`). Increase if spot provisioning fails with "no good choice". |
+| `--spot-eviction-tolerance` | Spot tolerance: `lowest`, `low`, `medium`, `high`, `highest`. Defaults to `highest` when `--spot` is used (GPU workloads are typically testing, not production). Override with a lower value only if the user explicitly needs long-running stability. |
 | `--tags` | Cost attribution: `team=myteam,env=dev` |
 | `--project-name` | Stack identifier (default: auto-generated) |
 

--- a/claudio-plugin/skills/mapt-provisioner/SKILL.md
+++ b/claudio-plugin/skills/mapt-provisioner/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: mapt-provisioner
+description: Provision and manage cloud machines and services using mapt. Use this skill when the user asks to create, destroy, or check the status of cloud VMs, RHELAI instances, OpenShift clusters (SNC), or any infrastructure that mapt supports. Covers AWS and Azure providers. Handles spot instances, GPU-enabled workloads, and OpenShift profiles.
+compatibility: Requires MAPT_BACKEND_URL. AWS targets need AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (or AWS_PROFILE) and AWS_DEFAULT_REGION. Azure targets need ARM_TENANT_ID, ARM_SUBSCRIPTION_ID, ARM_CLIENT_ID, and ARM_CLIENT_SECRET (mapt maps these to AZURE_* internally); azblob backend also needs AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY. SNC targets also need PULL_SECRET_FILE.
+allowed-tools: Bash(*/mapt-provisioner/scripts/*.sh:*),Bash(*/tools/mapt/install.sh:*),Bash(mapt * --help),Bash(ssh -i /tmp/mapt-conn-details/* *)
+---
+
+# Mapt Provisioner
+
+Provision and manage cloud machines and services using [mapt](https://github.com/redhat-developer/mapt).
+
+## Interpreting Natural Language Requests
+
+Users will ask in natural language — extract the intent and map it to script flags. Do not require a specific incantation.
+
+| User says | Maps to |
+|-----------|---------|
+| "RHEL AI" / "RHELAI" / "rhel-ai" | `provision_rhelai.sh` |
+| "OpenShift" / "SNC" / "single-node" | `provision_snc.sh` |
+| "on AWS" / "in AWS" / "using AWS" | `--provider aws` |
+| "on Azure" / "in Azure" | `--provider azure` |
+| "spot" / "spot instance" / "using spot" | `--spot` |
+| "tag it X=Y" / "tags X=Y,A=B" | `--tags X=Y,A=B` |
+| "store state in s3://..." / "backend s3://..." | set `MAPT_BACKEND_URL=s3://...` |
+| "destroy it" / "tear it down" / "clean up" | `destroy.sh` |
+| "check status" / "is it up?" | `check_status.sh` |
+| "connect to it" / "SSH in" / "run X on it" | SSH directly using conn-details |
+
+**Env var defaults:** `AWS_DEFAULT_REGION` and credentials should be pre-configured in the environment — do not ask the user to provide them in their request. If `MAPT_BACKEND_URL` is already set in the environment, the user does not need to mention it either.
+
+## Rules
+
+- **DO NOT provision without `MAPT_BACKEND_URL` set.** Without a persistent state backend, provisioned resources become orphaned — VMs, GPUs, and networking bill indefinitely with no way to destroy them through mapt. The scripts enforce this, but do not attempt to bypass it.
+- **DO NOT destroy without confirming the project name and target with the user.** Echo back the project name, provider, and target type. Wait for explicit confirmation before running destroy.
+- **DO NOT use `--force-destroy` without user confirmation.** Only use when the user confirms a Pulumi lock is stale.
+- **DO NOT provision GPU instances without confirming cost implications.** GPU instances are significantly more expensive than standard instances.
+- **Always remind the user about ongoing charges** after provisioning. Provide the project name and the exact destroy command they'll need later.
+
+## Provisioning Workflow
+
+### Step 1: Pre-Flight
+
+Before running any provisioning script, verify the required environment variables are set:
+
+| Target | Required Variables |
+|--------|--------------------|
+| All | `MAPT_BACKEND_URL` (s3://... or azblob://...) |
+| AWS | `AWS_DEFAULT_REGION` (e.g. `us-east-1`) — needed for AWS SDK initialization; should be pre-configured in the environment, not extracted from the user's request. mapt still picks the cheapest spot region globally regardless of this value. |
+| AWS | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, or `AWS_PROFILE` |
+| Azure | `ARM_TENANT_ID`, `ARM_SUBSCRIPTION_ID`, `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET` (mapt maps these to `AZURE_*` internally via `setAZIdentityEnvs()`) |
+| Azure (azblob backend) | `AZURE_STORAGE_ACCOUNT`, `AZURE_STORAGE_KEY` |
+| Azure RHELAI (version auto-discovery) | `AZURE_GALLERY_RESOURCE_GROUP` — resource group mapt uses for image lookups; required when `--version` is not passed |
+| SNC (additionally) | `PULL_SECRET_FILE` (path to file from https://console.redhat.com/openshift/create/local) |
+
+If `MAPT_BACKEND_URL` is not set, **stop and explain the orphaned-resource risk**. Do NOT proceed.
+
+If your Pulumi state was encrypted with a non-default passphrase, export `PULUMI_CONFIG_PASSPHRASE=<your-passphrase>` before running. The scripts default to `passphrase`, which matches the mapt container configuration.
+
+OpenShift SNC is AWS only — mapt does not support Azure for SNC.
+
+### Step 2: Provision
+
+**RHELAI:**
+```bash
+/full/path/to/scripts/provision_rhelai.sh --provider <aws|azure> [options]
+```
+
+| Option | Purpose |
+|--------|---------|
+| `--version` | RHELAI version (default: 3.0.0) |
+| `--cpus`, `--memory` | Instance size |
+| `--gpus` | Number of GPUs |
+| `--accelerator` | GPU type: `cuda` or `rocm` (mapt default: cuda) |
+| `--spot` | Use spot instances (cheaper, can be interrupted) |
+| `--spot-eviction-tolerance` | Spot tolerance: `lowest`, `low`, `medium`, `high`, `highest` (default: `lowest`). Increase if spot provisioning fails with "no good choice". |
+| `--tags` | Cost attribution: `team=myteam,env=dev` |
+| `--project-name` | Stack identifier (default: auto-generated) |
+
+**OpenShift SNC:**
+```bash
+/full/path/to/scripts/provision_snc.sh [options]
+```
+
+| Option | Purpose |
+|--------|---------|
+| `--version` | OpenShift version (default: 4.21.0) |
+| `--profile` | Comma-separated: `virtualization`, `serverless`, `serverless-serving`, `serverless-eventing`, `servicemesh`, `ai`, `nvidia` |
+| `--arch` | `x86_64` or `arm64` (mapt default: x86_64) |
+| `--spot` | Use spot instances |
+| `--tags` | Cost attribution |
+| `--pull-secret-file` | Overrides `PULL_SECRET_FILE` env var |
+| `--project-name` | Stack identifier (default: auto-generated) |
+
+The `ai` profile automatically includes `servicemesh` and `serverless-serving` and raises minimum instance size to 16 vCPUs.
+
+### Handling Failures — Hard Stop Rules
+
+These are **blocking rules**. Each one requires a full stop and explicit user confirmation before taking any further action — including cleanup, retries, or waiting.
+
+**STOP immediately and ask the user when:**
+- Auto-discovered version contains `-ea` — do not run the provision script. Show the EA version and ask whether to proceed, use a different accelerator, or specify a version manually.
+- Provisioning fails for any reason — do not retry with different parameters. Report the exact error and offer options. Wait for the user to choose one.
+- A destroy step fails — keep going until it succeeds. Monitor the output, detect transient errors (e.g. Azure NIC reservation, lock conflicts), wait the duration indicated in the error, and retry automatically. Tell the user what you're waiting for. Only stop and report if a non-transient error occurs (e.g. credentials expired, stack not found).
+- Any step produces a partial resource state — do not chain follow-up actions. Report what was created and what failed, then stop.
+
+**Never:**
+- Retry autonomously with different flags (`--version`, `--spot`, `--accelerator`, etc.)
+- Schedule a delayed retry (e.g. `sleep 180 && destroy`) without explicit user instruction
+- Chain a retry onto a destroy without the user confirming both steps separately
+
+### Step 3: Verify and Report
+
+After provisioning completes:
+
+1. Run `check_status.sh` to confirm the stack exists:
+```bash
+/full/path/to/scripts/check_status.sh --project-name <project-name>
+```
+2. Show the user: connection details, project name, and the destroy command for later.
+
+## Destroy Workflow
+
+### Step 1: Confirm with User
+
+Before destroying, echo back and get explicit confirmation:
+- Project name
+- Provider (aws or azure)
+- Target type (rhel-ai, openshift-snc, rhel, fedora, mac, windows, kind, eks, aks, ubuntu)
+
+### Step 2: Destroy
+
+```bash
+/full/path/to/scripts/destroy.sh --provider <provider> --target <target> --project-name <name>
+```
+
+If destroy fails with a Pulumi lock error: explain that a stale lock is blocking (common in container environments), ask if the user wants to force it, and only then retry with `--force-destroy`.
+
+### Step 3: Verify
+
+Run `check_status.sh` to confirm the stack is gone.
+
+## Connect to a Provisioned Machine
+
+After provisioning, connection details are written to `/tmp/mapt-conn-details/<project-name>/`. The SSH key lives there — use SSH directly rather than printing the command for the user to run.
+
+When the user asks to connect or run something on the machine, **always show the exact SSH command first and wait for confirmation** before executing. This is a live VM with real cloud costs — never run commands autonomously without the user knowing what will execute.
+
+```bash
+ssh -i /tmp/mapt-conn-details/<project-name>/id_rsa \
+    -o StrictHostKeyChecking=no \
+    cloud-user@<host> "<command>"
+```
+
+For read-only checks (e.g. `hostname`, `uname -r`, `systemctl status`) you may execute immediately after showing the command. For anything that modifies system state, explicitly wait for the user to confirm.
+
+The host is the ELB DNS name shown in the provisioning output. If connection details are missing, run `check_status.sh` — it will display them if they exist locally, or retrieve the project name from Pulumi state.
+
+## Check Status
+
+```bash
+/full/path/to/scripts/check_status.sh --project-name <project-name>
+```
+
+Queries the Pulumi state backend directly (mapt has no native status command) and displays connection details if available locally.
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Missing credentials | Env vars not set | Tell user which specific variables to set for their provider |
+| `MAPT_BACKEND_URL` not set | No state backend | **Stop.** Explain orphaned-resource risk. Do not proceed. |
+| Backend unreachable | S3 bucket or Azure blob doesn't exist or no access | Verify URL and credentials. If state is lost, resources must be cleaned up manually via cloud console. |
+| Quota exceeded | Cloud provider capacity limits | Try different instance size, try `--spot`, or increase quotas with provider |
+| Pulumi lock stale | Previous session died without releasing lock | Use `--force-destroy` after user confirmation |
+| Spot eviction | Cloud provider reclaimed the instance | Re-provision. Recommend without `--spot` for long-running workloads. |
+| Provisioning hangs | Cloud provider issue or resource unavailability | Check cloud console for partial resources. Project name + backend URL help locate Pulumi state for manual cleanup. |
+
+## Installation
+
+mapt is installed automatically when any script is run (via `_common.sh`). You do not need to install it manually. If a script fails with a mapt-related error unrelated to installation, check the error message directly.

--- a/claudio-plugin/skills/mapt-provisioner/scripts/_common.sh
+++ b/claudio-plugin/skills/mapt-provisioner/scripts/_common.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Common helpers for mapt-provisioner scripts.
+# Sourced by all scripts in this directory.
+#
+# Required environment variables (varies by operation):
+#   MAPT_BACKEND_URL        - Pulumi state backend URL (always required)
+#   AWS_PROFILE             - AWS profile (alternative to explicit keys, e.g. saml)
+#   AWS_ACCESS_KEY_ID       - AWS credential (for AWS targets, if not using AWS_PROFILE)
+#   AWS_SECRET_ACCESS_KEY   - AWS credential (for AWS targets, if not using AWS_PROFILE)
+#   ARM_TENANT_ID           - Azure credential (for Azure targets; mapt maps ARM_* -> AZURE_* internally)
+#   ARM_SUBSCRIPTION_ID     - Azure credential (for Azure targets)
+#   ARM_CLIENT_ID           - Azure credential (for Azure targets)
+#   ARM_CLIENT_SECRET       - Azure credential (for Azure targets)
+#   AZURE_STORAGE_ACCOUNT        - Azure storage account name (for azblob state backend)
+#   AZURE_STORAGE_KEY            - Azure storage account key (for azblob state backend)
+#   AZURE_GALLERY_RESOURCE_GROUP - Resource group mapt uses for image lookups (for Azure version auto-discovery)
+#   PULL_SECRET_FILE             - Path to OpenShift pull secret (for SNC targets)
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Ensure ~/.local/bin is on PATH (mapt install target)
+if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# Install mapt if not present — idempotent, skips immediately if already installed
+"$SCRIPTS_DIR/../../../tools/mapt/install.sh" >/dev/null
+
+# Set Pulumi passphrase if not already set (matches mapt Containerfile default)
+export PULUMI_CONFIG_PASSPHRASE="${PULUMI_CONFIG_PASSPHRASE:-passphrase}"
+
+# Default connection details output path
+DEFAULT_CONN_DETAILS_OUTPUT="/tmp/mapt-conn-details"
+
+require_arg() {
+    local flag="$1"
+    local value="${2:-}"
+    if [[ -z "$value" || "$value" == --* ]]; then
+        echo "ERROR: $flag requires a value" >&2
+        exit 1
+    fi
+}
+
+validate_backend_url() {
+    if [[ -z "${MAPT_BACKEND_URL:-}" ]]; then
+        echo "ERROR: MAPT_BACKEND_URL is required but not set." >&2
+        echo "  Set it to a persistent Pulumi state backend URL." >&2
+        echo "  Examples:" >&2
+        echo "    export MAPT_BACKEND_URL=s3://my-mapt-state" >&2
+        echo "    export MAPT_BACKEND_URL=azblob://my-state-container" >&2
+        echo "" >&2
+        echo "  A persistent backend is required to avoid orphaning cloud resources." >&2
+        echo "  Without it, if the container dies you lose the ability to destroy" >&2
+        echo "  provisioned resources (VMs, GPUs, networking) which keep billing." >&2
+        exit 1
+    fi
+
+    if [[ "${MAPT_BACKEND_URL}" == azblob://* ]]; then
+        local missing=()
+        [[ -z "${AZURE_STORAGE_ACCOUNT:-}" ]] && missing+=("AZURE_STORAGE_ACCOUNT")
+        [[ -z "${AZURE_STORAGE_KEY:-}" ]] && missing+=("AZURE_STORAGE_KEY")
+        if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "ERROR: azblob backend requires: ${missing[*]}" >&2
+            exit 1
+        fi
+    fi
+}
+
+validate_aws_credentials() {
+    if [[ -n "${AWS_PROFILE:-}" ]]; then
+        return 0
+    fi
+    local missing=()
+    [[ -z "${AWS_ACCESS_KEY_ID:-}" ]] && missing+=("AWS_ACCESS_KEY_ID")
+    [[ -z "${AWS_SECRET_ACCESS_KEY:-}" ]] && missing+=("AWS_SECRET_ACCESS_KEY")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "ERROR: Missing required AWS credentials." >&2
+        echo "  Either set AWS_PROFILE (for profile-based auth):" >&2
+        echo "    export AWS_PROFILE=saml" >&2
+        echo "  Or set explicit credentials:" >&2
+        echo "    export AWS_ACCESS_KEY_ID=..." >&2
+        echo "    export AWS_SECRET_ACCESS_KEY=..." >&2
+        exit 1
+    fi
+}
+
+validate_azure_credentials() {
+    local missing=()
+    [[ -z "${ARM_TENANT_ID:-}" ]] && missing+=("ARM_TENANT_ID")
+    [[ -z "${ARM_SUBSCRIPTION_ID:-}" ]] && missing+=("ARM_SUBSCRIPTION_ID")
+    [[ -z "${ARM_CLIENT_ID:-}" ]] && missing+=("ARM_CLIENT_ID")
+    [[ -z "${ARM_CLIENT_SECRET:-}" ]] && missing+=("ARM_CLIENT_SECRET")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "ERROR: Missing required Azure credentials: ${missing[*]}" >&2
+        echo "  mapt reads ARM_* vars and maps them to AZURE_* internally." >&2
+        exit 1
+    fi
+}
+
+validate_provider_credentials() {
+    local provider="$1"
+    case "$provider" in
+        aws)
+            validate_aws_credentials
+            ;;
+        azure)
+            validate_azure_credentials
+            ;;
+        *)
+            echo "ERROR: Unknown provider '$provider'. Supported: aws, azure" >&2
+            exit 1
+            ;;
+    esac
+}
+
+validate_pull_secret() {
+    if [[ -z "${PULL_SECRET_FILE:-}" ]]; then
+        echo "ERROR: PULL_SECRET_FILE is required but not set." >&2
+        echo "  Download the pull secret from https://console.redhat.com/openshift/create/local" >&2
+        echo "  Then: export PULL_SECRET_FILE=/path/to/pull-secret.json" >&2
+        exit 1
+    fi
+    if [[ ! -f "$PULL_SECRET_FILE" ]]; then
+        echo "ERROR: Pull secret file does not exist: $PULL_SECRET_FILE" >&2
+        exit 1
+    fi
+}
+
+generate_project_name() {
+    local target="$1"
+    echo "mapt-${target}-$(date +%Y%m%d-%H%M%S)-${RANDOM}"
+}
+
+log_connection_details() {
+    local output_dir="$1"
+    if [[ ! -d "$output_dir" ]]; then
+        echo "WARNING: Connection details directory not found: $output_dir" >&2
+        return 1
+    fi
+    echo "=== Connection Details ==="
+    for f in "$output_dir"/*; do
+        if [[ -f "$f" ]]; then
+            echo "--- $(basename "$f") ---"
+            cat "$f"
+            echo ""
+        fi
+    done
+}

--- a/claudio-plugin/skills/mapt-provisioner/scripts/check_status.sh
+++ b/claudio-plugin/skills/mapt-provisioner/scripts/check_status.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Check status of a mapt-provisioned target.
+#
+# Usage:
+#   ./check_status.sh --project-name <name> [--conn-details-output <path>]
+#
+# Required environment variables:
+#   MAPT_BACKEND_URL - Pulumi state backend URL
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+PROJECT_NAME=""
+CONN_DETAILS_OUTPUT=""
+
+usage() {
+    echo "Usage: $(basename "$0") --project-name <name> [--conn-details-output <path>]"
+    echo ""
+    echo "Options:"
+    echo "  --project-name          Stack identifier (required)"
+    echo "  --conn-details-output   Path to check for connection details (default: /tmp/mapt-conn-details)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --project-name) require_arg "$1" "${2:-}"; PROJECT_NAME="$2"; shift 2 ;;
+        --conn-details-output) require_arg "$1" "${2:-}"; CONN_DETAILS_OUTPUT="$2"; shift 2 ;;
+        *) echo "ERROR: Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$PROJECT_NAME" ]]; then
+    echo "ERROR: --project-name is required" >&2
+    usage
+fi
+
+validate_backend_url
+
+if ! command -v jq &>/dev/null; then
+    echo "ERROR: jq is required but not installed" >&2
+    exit 1
+fi
+
+CONN_DETAILS_OUTPUT="${CONN_DETAILS_OUTPUT:-$DEFAULT_CONN_DETAILS_OUTPUT/$PROJECT_NAME}"
+
+echo "Checking status for project: $PROJECT_NAME"
+echo "  State backend: [configured]"
+echo ""
+
+if ! STACK_INFO=$(PULUMI_BACKEND_URL="$MAPT_BACKEND_URL" pulumi stack ls --json --all); then
+    echo "ERROR: Failed to query Pulumi backend. Check MAPT_BACKEND_URL and credentials." >&2
+    exit 1
+fi
+
+if ! echo "$STACK_INFO" | jq '.' >/dev/null; then
+    echo "ERROR: Pulumi returned invalid JSON. Raw output:" >&2
+    echo "$STACK_INFO" >&2
+    exit 1
+fi
+
+if echo "$STACK_INFO" | jq -e --arg name "$PROJECT_NAME" '.[] | select(.name | contains($name))' >/dev/null; then
+    echo "✓ Project '$PROJECT_NAME' exists in state backend"
+    echo ""
+    echo "Stack details:"
+    echo "$STACK_INFO" | jq -r --arg name "$PROJECT_NAME" '
+        .[] | select(.name | contains($name)) |
+        "  Name:          \(.name // "N/A")",
+        "  Last updated:  \(.lastUpdate // "N/A")",
+        "  Resource count: \(.resourceCount // "N/A")"
+    '
+else
+    echo "✗ Project '$PROJECT_NAME' not found in state backend"
+    exit 1
+fi
+
+echo ""
+if [[ -d "$CONN_DETAILS_OUTPUT" ]]; then
+    log_connection_details "$CONN_DETAILS_OUTPUT"
+else
+    echo "No connection details found at $CONN_DETAILS_OUTPUT"
+fi

--- a/claudio-plugin/skills/mapt-provisioner/scripts/destroy.sh
+++ b/claudio-plugin/skills/mapt-provisioner/scripts/destroy.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Destroy a mapt-provisioned target.
+#
+# Usage:
+#   ./destroy.sh --provider <aws|azure> --target <rhel-ai|openshift-snc|...> --project-name <name>
+#
+# Required environment variables:
+#   MAPT_BACKEND_URL - Pulumi state backend URL
+#   Provider-specific credentials (AWS or Azure)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+PROVIDER=""
+TARGET=""
+PROJECT_NAME=""
+FORCE_DESTROY=false
+
+usage() {
+    echo "Usage: $(basename "$0") --provider <aws|azure> --target <target> --project-name <name>"
+    echo ""
+    echo "Options:"
+    echo "  --provider        Cloud provider: aws or azure (required)"
+    echo "  --target          Target type: rhel-ai, openshift-snc, rhel, fedora, etc. (required)"
+    echo "  --project-name    Stack identifier used during provisioning (required)"
+    echo "  --force-destroy   Force destroy even if Pulumi lock is stale"
+    echo ""
+    echo "Supported targets by provider:"
+    echo "  AWS:   rhel-ai, openshift-snc, rhel, fedora, mac, kind, eks"
+    echo "  Azure: rhel-ai, rhel, fedora, windows, ubuntu, kind, aks"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --provider) require_arg "$1" "${2:-}"; PROVIDER="$2"; shift 2 ;;
+        --target) require_arg "$1" "${2:-}"; TARGET="$2"; shift 2 ;;
+        --project-name) require_arg "$1" "${2:-}"; PROJECT_NAME="$2"; shift 2 ;;
+        --force-destroy) FORCE_DESTROY=true; shift ;;
+        *) echo "ERROR: Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$PROVIDER" ]]; then
+    echo "ERROR: --provider is required" >&2
+    usage
+fi
+
+if [[ -z "$TARGET" ]]; then
+    echo "ERROR: --target is required" >&2
+    usage
+fi
+
+if [[ -z "$PROJECT_NAME" ]]; then
+    echo "ERROR: --project-name is required" >&2
+    usage
+fi
+
+validate_backend_url
+validate_provider_credentials "$PROVIDER"
+
+case "$PROVIDER:$TARGET" in
+    aws:rhel-ai|aws:openshift-snc|aws:rhel|aws:fedora|aws:mac|aws:kind|aws:eks|\
+    azure:rhel-ai|azure:rhel|azure:fedora|azure:windows|azure:ubuntu|azure:kind|azure:aks)
+        ;;
+    *)
+        echo "ERROR: Target '$TARGET' is not supported for provider '$PROVIDER'" >&2
+        usage
+        ;;
+esac
+
+echo "Destroying mapt target..."
+echo "  Provider:      $PROVIDER"
+echo "  Target:        $TARGET"
+echo "  Project:       $PROJECT_NAME"
+echo "  State backend: [configured]"
+echo ""
+
+CMD=(mapt "$PROVIDER" "$TARGET" destroy
+    --project-name "$PROJECT_NAME"
+    --backed-url "$MAPT_BACKEND_URL"
+)
+
+[[ "$FORCE_DESTROY" = true ]] && CMD+=(--force-destroy)
+
+"${CMD[@]}"
+
+echo ""
+echo "✓ Target destroyed successfully"

--- a/claudio-plugin/skills/mapt-provisioner/scripts/get_azure_rhelai_version.sh
+++ b/claudio-plugin/skills/mapt-provisioner/scripts/get_azure_rhelai_version.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Discover the latest RHEL AI version available in the Azure Compute Gallery
+# for the given accelerator type, across all resource groups in the subscription.
+#
+# Usage:
+#   ./get_azure_rhelai_version.sh [--accelerator cuda|rocm]
+#
+# Outputs: the latest version string (e.g. "3.2.0") on stdout
+#
+# Required environment variables:
+#   ARM_TENANT_ID, ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_SUBSCRIPTION_ID
+#   AZURE_GALLERY_RESOURCE_GROUP - resource group mapt uses for image lookups (e.g. aipcc-productization)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+validate_azure_credentials
+
+ACCELERATOR="cuda"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --accelerator) require_arg "$1" "${2:-}"; ACCELERATOR="$2"; shift 2 ;;
+        *) echo "ERROR: Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "${AZURE_GALLERY_RESOURCE_GROUP:-}" ]]; then
+    echo "ERROR: AZURE_GALLERY_RESOURCE_GROUP is required (resource group mapt uses for image lookups)" >&2
+    exit 1
+fi
+GALLERY_PREFIX="rhel_ai_${ACCELERATOR}_azure_"
+
+# Authenticate with service principal and get access token
+# Use -d with pre-encoded scope; --data-urlencode corrupts client_secret when
+# the secret contains special characters, causing Azure to reject the request.
+TOKEN=$(curl -sf -X POST \
+    "https://login.microsoftonline.com/${ARM_TENANT_ID}/oauth2/v2.0/token" \
+    -d "grant_type=client_credentials&client_id=${ARM_CLIENT_ID}&client_secret=${ARM_CLIENT_SECRET}&scope=https%3A%2F%2Fmanagement.azure.com%2F.default" \
+    | jq -r '.access_token')
+
+if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+    echo "ERROR: Failed to obtain Azure access token" >&2
+    exit 1
+fi
+
+# List galleries in the subscription filtered to the target resource group.
+# Filtering by RG is critical: galleries in other RGs (e.g. RHEL-AI-CUDA-AZURE-3.0.0)
+# are unreachable by mapt, which hardcodes the RG for image lookups.
+# Comparison is case-insensitive because Azure normalises RG names to uppercase in resource IDs.
+GALLERIES=$(curl -sf \
+    -H "Authorization: Bearer ${TOKEN}" \
+    "https://management.azure.com/subscriptions/${ARM_SUBSCRIPTION_ID}/providers/Microsoft.Compute/galleries?api-version=2022-03-03" \
+    | jq -r --arg rg "${AZURE_GALLERY_RESOURCE_GROUP}" \
+        '.value[] | select(.id | ascii_downcase | contains("/resourcegroups/\($rg | ascii_downcase)/")) | .name')
+
+# Filter for rhel_ai_{accelerator}_azure_* and extract versions.
+# Gallery names use all underscores (mapt replaces all hyphens with underscores when
+# building gallery names), so convert back to hyphens to get the correct version string
+# to pass to mapt (e.g. gallery "rhel_ai_cuda_azure_3.4.0_ea.2" → version "3.4.0-ea.2").
+VERSIONS=$(echo "$GALLERIES" \
+    | { grep "^${GALLERY_PREFIX}" || true; } \
+    | sed "s/^${GALLERY_PREFIX}//" \
+    | tr '_' '-')
+
+if [[ -z "$VERSIONS" ]]; then
+    echo "ERROR: No RHEL AI images found for accelerator '${ACCELERATOR}' in subscription" >&2
+    echo "  Available galleries:" >&2
+    echo "$GALLERIES" | grep "^rhel_ai_" >&2 || echo "  (none)" >&2
+    exit 1
+fi
+
+# Prefer stable (non-EA) versions; fall back to EA only if no stable exists.
+# grep exits 1 on no match so use || true to avoid killing the script under pipefail.
+STABLE=$(echo "$VERSIONS" | { grep -v "\-ea" || true; } | sort -V | tail -1)
+LATEST="${STABLE:-$(echo "$VERSIONS" | sort -V | tail -1)}"
+
+if [[ -z "$STABLE" ]]; then
+    echo "WARNING: Only EA versions available for accelerator '${ACCELERATOR}'. Consider passing --version and --accelerator explicitly." >&2
+fi
+
+echo "$LATEST"

--- a/claudio-plugin/skills/mapt-provisioner/scripts/get_azure_rhelai_version.sh
+++ b/claudio-plugin/skills/mapt-provisioner/scripts/get_azure_rhelai_version.sh
@@ -4,9 +4,10 @@
 # for the given accelerator type, across all resource groups in the subscription.
 #
 # Usage:
-#   ./get_azure_rhelai_version.sh [--accelerator cuda|rocm]
+#   ./get_azure_rhelai_version.sh [--accelerator cuda|rocm] [--list]
 #
 # Outputs: the latest version string (e.g. "3.2.0") on stdout
+#          with --list: all available versions, one per line, sorted
 #
 # Required environment variables:
 #   ARM_TENANT_ID, ARM_CLIENT_ID, ARM_CLIENT_SECRET, ARM_SUBSCRIPTION_ID
@@ -20,10 +21,12 @@ source "$SCRIPT_DIR/_common.sh"
 validate_azure_credentials
 
 ACCELERATOR="cuda"
+LIST=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         --accelerator) require_arg "$1" "${2:-}"; ACCELERATOR="$2"; shift 2 ;;
+        --list) LIST=true; shift ;;
         *) echo "ERROR: Unknown option: $1" >&2; exit 1 ;;
     esac
 done
@@ -71,6 +74,11 @@ if [[ -z "$VERSIONS" ]]; then
     echo "  Available galleries:" >&2
     echo "$GALLERIES" | grep "^rhel_ai_" >&2 || echo "  (none)" >&2
     exit 1
+fi
+
+if [[ "$LIST" = true ]]; then
+    echo "$VERSIONS" | sort -V
+    exit 0
 fi
 
 # Prefer stable (non-EA) versions; fall back to EA only if no stable exists.

--- a/claudio-plugin/skills/mapt-provisioner/scripts/provision_rhelai.sh
+++ b/claudio-plugin/skills/mapt-provisioner/scripts/provision_rhelai.sh
@@ -43,7 +43,7 @@ usage() {
     echo "  --disk-size             Disk size in GB"
     echo "  --accelerator               GPU accelerator: cuda or rocm (mapt default: cuda)"
     echo "  --compute-sizes             Comma-separated VM sizes to constrain spot selection (e.g. Standard_E8s_v5,Standard_E16s_v5)"
-    echo "  --spot-eviction-tolerance   Spot tolerance: lowest, low, medium, high, highest (default: lowest)"
+    echo "  --spot-eviction-tolerance   Spot tolerance: lowest, low, medium, high, highest (default: highest when --spot)"
     echo "  --tags                      Key=value tags for cost attribution (e.g. team=myteam,env=dev)"
     echo "  --spot                      Use spot instances"
     echo "  --conn-details-output   Path for connection details (default: /tmp/mapt-conn-details)"
@@ -76,6 +76,12 @@ fi
 
 validate_backend_url
 validate_provider_credentials "$PROVIDER"
+
+# Default spot-eviction-tolerance to highest when using spot — GPU workloads
+# provisioned through this skill are typically testing/demo, not production.
+if [[ "$SPOT" = true && -z "$SPOT_EVICTION_TOLERANCE" ]]; then
+    SPOT_EVICTION_TOLERANCE="highest"
+fi
 
 # For Azure, discover the latest available gallery image version when not specified
 if [[ "$PROVIDER" == "azure" && -z "$VERSION" ]]; then

--- a/claudio-plugin/skills/mapt-provisioner/scripts/provision_rhelai.sh
+++ b/claudio-plugin/skills/mapt-provisioner/scripts/provision_rhelai.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Provision a RHELAI instance using mapt.
+#
+# Usage:
+#   ./provision_rhelai.sh --provider <aws|azure> [options]
+#
+# Required environment variables:
+#   MAPT_BACKEND_URL - Pulumi state backend URL
+#   AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (for --provider aws)
+#   ARM_TENANT_ID / ARM_SUBSCRIPTION_ID / ARM_CLIENT_ID / ARM_CLIENT_SECRET (for --provider azure)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+# Defaults
+PROVIDER=""
+PROJECT_NAME=""
+VERSION=""
+CPUS=""
+MEMORY=""
+GPUS=""
+DISK_SIZE=""
+ACCELERATOR=""
+COMPUTE_SIZES=""
+SPOT_EVICTION_TOLERANCE=""
+TAGS=""
+SPOT=false
+CONN_DETAILS_OUTPUT=""
+
+usage() {
+    echo "Usage: $(basename "$0") --provider <aws|azure> [options]"
+    echo ""
+    echo "Options:"
+    echo "  --provider              Cloud provider: aws or azure (required)"
+    echo "  --project-name          Stack identifier (default: auto-generated)"
+    echo "  --version               RHELAI version (azure: auto-discovered; aws: mapt default)"
+    echo "  --cpus                  Number of CPUs"
+    echo "  --memory                Memory in GiB"
+    echo "  --gpus                  Number of GPUs"
+    echo "  --disk-size             Disk size in GB"
+    echo "  --accelerator               GPU accelerator: cuda or rocm (mapt default: cuda)"
+    echo "  --compute-sizes             Comma-separated VM sizes to constrain spot selection (e.g. Standard_E8s_v5,Standard_E16s_v5)"
+    echo "  --spot-eviction-tolerance   Spot tolerance: lowest, low, medium, high, highest (default: lowest)"
+    echo "  --tags                      Key=value tags for cost attribution (e.g. team=myteam,env=dev)"
+    echo "  --spot                      Use spot instances"
+    echo "  --conn-details-output   Path for connection details (default: /tmp/mapt-conn-details)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --provider) require_arg "$1" "${2:-}"; PROVIDER="$2"; shift 2 ;;
+        --project-name) require_arg "$1" "${2:-}"; PROJECT_NAME="$2"; shift 2 ;;
+        --version) require_arg "$1" "${2:-}"; VERSION="$2"; shift 2 ;;
+        --cpus) require_arg "$1" "${2:-}"; CPUS="$2"; shift 2 ;;
+        --memory) require_arg "$1" "${2:-}"; MEMORY="$2"; shift 2 ;;
+        --gpus) require_arg "$1" "${2:-}"; GPUS="$2"; shift 2 ;;
+        --disk-size) require_arg "$1" "${2:-}"; DISK_SIZE="$2"; shift 2 ;;
+        --accelerator) require_arg "$1" "${2:-}"; ACCELERATOR="$2"; shift 2 ;;
+        --compute-sizes) require_arg "$1" "${2:-}"; COMPUTE_SIZES="$2"; shift 2 ;;
+        --spot-eviction-tolerance) require_arg "$1" "${2:-}"; SPOT_EVICTION_TOLERANCE="$2"; shift 2 ;;
+        --tags) require_arg "$1" "${2:-}"; TAGS="$2"; shift 2 ;;
+        --spot) SPOT=true; shift ;;
+        --conn-details-output) require_arg "$1" "${2:-}"; CONN_DETAILS_OUTPUT="$2"; shift 2 ;;
+        *) echo "ERROR: Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$PROVIDER" ]]; then
+    echo "ERROR: --provider is required" >&2
+    usage
+fi
+
+validate_backend_url
+validate_provider_credentials "$PROVIDER"
+
+# For Azure, discover the latest available gallery image version when not specified
+if [[ "$PROVIDER" == "azure" && -z "$VERSION" ]]; then
+    echo "Discovering latest RHEL AI version in Azure gallery..."
+    ACCEL_ARG="${ACCELERATOR:-cuda}"
+    VERSION=$("$SCRIPT_DIR/get_azure_rhelai_version.sh" --accelerator "$ACCEL_ARG")
+    echo "  Found version: $VERSION"
+    if [[ "$VERSION" == *"-ea"* ]]; then
+        echo "" >&2
+        echo "ERROR: Only Early Access (EA) versions are available for accelerator '${ACCEL_ARG}' in the gallery." >&2
+        echo "  Discovered version: $VERSION" >&2
+        echo "" >&2
+        echo "  EA versions are pre-release and may cause failures. Options:" >&2
+        echo "    1. Use a different accelerator: --accelerator rocm" >&2
+        echo "    2. Proceed explicitly: --version $VERSION --accelerator $ACCEL_ARG" >&2
+        exit 1
+    fi
+fi
+
+if [[ -z "$PROJECT_NAME" ]]; then
+    PROJECT_NAME=$(generate_project_name "rhelai")
+fi
+CONN_DETAILS_OUTPUT="${CONN_DETAILS_OUTPUT:-$DEFAULT_CONN_DETAILS_OUTPUT/$PROJECT_NAME}"
+
+echo "Provisioning RHELAI instance..."
+echo "  Provider:     $PROVIDER"
+echo "  Project:      $PROJECT_NAME"
+echo "  Version:      ${VERSION:-(mapt default)}"
+echo "  State backend: [configured]"
+
+CMD=(mapt "$PROVIDER" rhel-ai create
+    --project-name "$PROJECT_NAME"
+    --backed-url "$MAPT_BACKEND_URL"
+    --conn-details-output "$CONN_DETAILS_OUTPUT"
+)
+[[ -n "$VERSION" ]] && CMD+=(--version "$VERSION")
+
+[[ -n "$CPUS" ]] && CMD+=(--cpus "$CPUS")
+[[ -n "$MEMORY" ]] && CMD+=(--memory "$MEMORY")
+[[ -n "$GPUS" ]] && CMD+=(--gpus "$GPUS")
+[[ -n "$DISK_SIZE" ]] && CMD+=(--disk-size "$DISK_SIZE")
+[[ -n "$ACCELERATOR" ]] && CMD+=(--accelerator "$ACCELERATOR")
+[[ -n "$COMPUTE_SIZES" ]] && CMD+=(--compute-sizes "$COMPUTE_SIZES")
+[[ -n "$SPOT_EVICTION_TOLERANCE" ]] && CMD+=(--spot-eviction-tolerance "$SPOT_EVICTION_TOLERANCE")
+[[ -n "$TAGS" ]] && CMD+=(--tags "$TAGS")
+[[ "$SPOT" = true ]] && CMD+=(--spot)
+
+echo "  Command:      ${CMD[*]//$MAPT_BACKEND_URL/[configured]}"
+echo ""
+
+mkdir -p "$CONN_DETAILS_OUTPUT"
+"${CMD[@]}"
+
+echo ""
+echo "✓ RHELAI instance provisioned successfully"
+echo "  Project name: $PROJECT_NAME (use this to destroy later)"
+echo ""
+log_connection_details "$CONN_DETAILS_OUTPUT"

--- a/claudio-plugin/skills/mapt-provisioner/scripts/provision_snc.sh
+++ b/claudio-plugin/skills/mapt-provisioner/scripts/provision_snc.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Provision an OpenShift Single Node Cluster (SNC) using mapt.
+# AWS only - mapt does not support Azure SNC.
+#
+# Usage:
+#   ./provision_snc.sh [options]
+#
+# Required environment variables:
+#   MAPT_BACKEND_URL         - Pulumi state backend URL
+#   AWS_ACCESS_KEY_ID       - AWS access key
+#   AWS_SECRET_ACCESS_KEY   - AWS secret key
+#   PULL_SECRET_FILE        - Path to OpenShift pull secret file
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+# Defaults
+PROJECT_NAME=""
+VERSION="4.21.0"
+PROFILE=""
+ARCH=""
+TAGS=""
+SPOT=false
+CONN_DETAILS_OUTPUT=""
+
+usage() {
+    echo "Usage: $(basename "$0") [options]"
+    echo ""
+    echo "Options:"
+    echo "  --project-name          Stack identifier (default: auto-generated)"
+    echo "  --version               OpenShift version (default: 4.21.0)"
+    echo "  --pull-secret-file      Path to pull secret (overrides PULL_SECRET_FILE env var)"
+    echo "  --profile               Comma-separated profiles: virtualization, serverless,"
+    echo "                          serverless-serving, serverless-eventing, servicemesh, ai, nvidia"
+    echo "  --arch                  Architecture: x86_64 or arm64 (mapt default: x86_64)"
+    echo "  --tags                  Key=value tags for cost attribution (e.g. team=myteam,env=dev)"
+    echo "  --spot                  Use spot instances"
+    echo "  --conn-details-output   Path for connection details (default: /tmp/mapt-conn-details)"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --project-name) require_arg "$1" "${2:-}"; PROJECT_NAME="$2"; shift 2 ;;
+        --version) require_arg "$1" "${2:-}"; VERSION="$2"; shift 2 ;;
+        --pull-secret-file) require_arg "$1" "${2:-}"; PULL_SECRET_FILE="$2"; shift 2 ;;
+        --profile) require_arg "$1" "${2:-}"; PROFILE="$2"; shift 2 ;;
+        --arch) require_arg "$1" "${2:-}"; ARCH="$2"; shift 2 ;;
+        --tags) require_arg "$1" "${2:-}"; TAGS="$2"; shift 2 ;;
+        --spot) SPOT=true; shift ;;
+        --conn-details-output) require_arg "$1" "${2:-}"; CONN_DETAILS_OUTPUT="$2"; shift 2 ;;
+        *) echo "ERROR: Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+validate_backend_url
+validate_aws_credentials
+validate_pull_secret
+
+if [[ -z "$PROJECT_NAME" ]]; then
+    PROJECT_NAME=$(generate_project_name "snc")
+fi
+CONN_DETAILS_OUTPUT="${CONN_DETAILS_OUTPUT:-$DEFAULT_CONN_DETAILS_OUTPUT/$PROJECT_NAME}"
+
+echo "Provisioning OpenShift SNC..."
+echo "  Provider:      AWS"
+echo "  Project:       $PROJECT_NAME"
+echo "  Version:       $VERSION"
+echo "  Pull secret:   $PULL_SECRET_FILE"
+echo "  State backend: [configured]"
+
+CMD=(mapt aws openshift-snc create
+    --project-name "$PROJECT_NAME"
+    --backed-url "$MAPT_BACKEND_URL"
+    --version "$VERSION"
+    --pull-secret-file "$PULL_SECRET_FILE"
+    --conn-details-output "$CONN_DETAILS_OUTPUT"
+)
+
+[[ -n "$PROFILE" ]] && CMD+=(--profile "$PROFILE")
+[[ -n "$ARCH" ]] && CMD+=(--arch "$ARCH")
+[[ -n "$TAGS" ]] && CMD+=(--tags "$TAGS")
+[[ "$SPOT" = true ]] && CMD+=(--spot)
+
+echo "  Command:       ${CMD[*]//$MAPT_BACKEND_URL/[configured]}"
+echo ""
+
+mkdir -p "$CONN_DETAILS_OUTPUT"
+"${CMD[@]}"
+
+echo ""
+echo "✓ OpenShift SNC provisioned successfully"
+echo "  Project name: $PROJECT_NAME (use this to destroy later)"
+echo ""
+log_connection_details "$CONN_DETAILS_OUTPUT"

--- a/claudio-plugin/tools/mapt/install.sh
+++ b/claudio-plugin/tools/mapt/install.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+#
+# Mapt + Pulumi Installation Script (Linux Only)
+#
+# This script installs or updates mapt, the Pulumi CLI, and all required
+# Pulumi provider plugins on Linux systems.
+# Supports: x86_64 and ARM64 (aarch64) architectures only.
+#
+# Usage:
+#   ./install.sh                # Check and install mapt + pulumi + providers
+#   ./install.sh --check        # Only check, don't install
+
+set -euo pipefail
+
+# ============================================================================
+# LOAD COMMON LIBRARY
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../common.sh
+source "$SCRIPT_DIR/../common.sh"
+
+# ============================================================================
+# DEPENDENCY VERSIONS
+# ============================================================================
+
+# renovate: datasource=github-releases depName=redhat-developer/mapt
+MAPT_VERSION="0.14.1"
+
+# renovate: datasource=github-releases depName=pulumi/pulumi
+PULUMI_VERSION="3.234.0"
+
+# Pulumi provider plugin versions (match mapt's oci/Containerfile)
+# renovate: datasource=github-releases depName=pulumi/pulumi-aws
+PULUMI_AWS_VERSION="7.28.0"
+# renovate: datasource=github-releases depName=pulumi/pulumi-awsx
+PULUMI_AWSX_VERSION="3.5.0"
+# renovate: datasource=github-releases depName=pulumi/pulumi-azure-native
+PULUMI_AZURE_NATIVE_VERSION="3.17.0"
+# renovate: datasource=github-releases depName=pulumi/pulumi-command
+PULUMI_COMMAND_VERSION="1.2.1"
+# renovate: datasource=github-releases depName=pulumi/pulumi-tls
+PULUMI_TLS_VERSION="5.3.1"
+# renovate: datasource=github-releases depName=pulumi/pulumi-random
+PULUMI_RANDOM_VERSION="4.19.2"
+# renovate: datasource=github-releases depName=pulumi/pulumi-aws-native
+PULUMI_AWS_NATIVE_VERSION="1.63.0"
+# renovate: datasource=github-releases depName=pulumi/pulumi-gitlab
+PULUMI_GITLAB_VERSION="9.11.0"
+
+# ============================================================================
+# CONFIGURATION
+# ============================================================================
+
+if [ -z "${INSTALL_DIR:-}" ]; then
+    if [ -w "/usr/local/bin" ]; then
+        INSTALL_DIR="/usr/local/bin"
+    else
+        INSTALL_DIR="$HOME/.local/bin"
+    fi
+fi
+
+_created_tmp=false
+if [ -z "${TMP_DIR:-}" ]; then
+    TMP_DIR=$(mktemp -d)
+    _created_tmp=true
+fi
+
+_cleanup_tmp() {
+    [ "$_created_tmp" = true ] && rm -rf "$TMP_DIR"
+}
+trap _cleanup_tmp EXIT
+
+# ============================================================================
+# HELPER FUNCTIONS
+# ============================================================================
+
+get_pulumi_version() {
+    if command_exists pulumi; then
+        pulumi version 2>&1 | sed 's/^v//' || echo "unknown"
+    else
+        echo "not_installed"
+    fi
+}
+
+# Map uname arch to pulumi download arch (pulumi uses x64, not x86_64)
+pulumi_arch() {
+    local arch
+    arch=$(detect_arch)
+    if [ "$arch" = "x86_64" ]; then
+        echo "x64"
+    else
+        echo "arm64"
+    fi
+}
+
+# Map uname arch to mapt release asset name
+mapt_arch() {
+    local arch
+    arch=$(detect_arch)
+    if [ "$arch" = "x86_64" ]; then
+        echo "amd64"
+    else
+        echo "arm64"
+    fi
+}
+
+# ============================================================================
+# CHECK FUNCTIONS
+# ============================================================================
+
+check_mapt() {
+    if ! command_exists mapt; then
+        log "mapt is not installed"
+        return 1
+    fi
+    local version_file="$INSTALL_DIR/mapt.version"
+    if [[ ! -f "$version_file" ]]; then
+        log "mapt version file missing, reinstalling"
+        return 1
+    fi
+    local installed_version
+    installed_version=$(cat "$version_file")
+    if [[ "$installed_version" != "$MAPT_VERSION" ]]; then
+        log "mapt version $installed_version does not match required $MAPT_VERSION"
+        return 1
+    fi
+    log "mapt $installed_version is up to date"
+    return 0
+}
+
+check_pulumi() {
+    local current_version
+
+    if ! command_exists pulumi; then
+        log "pulumi is not installed"
+        return 1
+    fi
+
+    current_version=$(get_pulumi_version)
+    log "pulumi version: $current_version"
+
+    if [ "$current_version" = "unknown" ]; then
+        log "Could not determine pulumi version"
+        return 1
+    fi
+
+    if version_gte "$current_version" "$PULUMI_VERSION"; then
+        log "pulumi is up to date (>= $PULUMI_VERSION)"
+        return 0
+    else
+        log "pulumi version $current_version is older than required $PULUMI_VERSION"
+        return 1
+    fi
+}
+
+check_pulumi_providers() {
+    if ! command_exists pulumi; then
+        log "pulumi not installed, cannot check providers"
+        return 1
+    fi
+
+    local missing=()
+    local installed
+    installed=$(pulumi plugin ls 2>/dev/null || echo "")
+
+    local -A providers=(
+        ["aws"]="$PULUMI_AWS_VERSION"
+        ["awsx"]="$PULUMI_AWSX_VERSION"
+        ["azure-native"]="$PULUMI_AZURE_NATIVE_VERSION"
+        ["command"]="$PULUMI_COMMAND_VERSION"
+        ["tls"]="$PULUMI_TLS_VERSION"
+        ["random"]="$PULUMI_RANDOM_VERSION"
+        ["aws-native"]="$PULUMI_AWS_NATIVE_VERSION"
+        ["gitlab"]="$PULUMI_GITLAB_VERSION"
+    )
+
+    for provider in "${!providers[@]}"; do
+        local escaped_version="${providers[$provider]//./\\.}"
+        if ! echo "$installed" | grep -qE "^${provider}[[:space:]]+resource[[:space:]]+${escaped_version}([[:space:]]|$)"; then
+            missing+=("${provider} v${providers[$provider]}")
+        fi
+    done
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        log "Missing pulumi providers: ${missing[*]}"
+        return 1
+    fi
+
+    log "All pulumi providers are installed"
+    return 0
+}
+
+check_all() {
+    local failed=false
+
+    if ! check_mapt; then failed=true; fi
+    if ! check_pulumi; then failed=true; fi
+    if ! check_pulumi_providers; then failed=true; fi
+
+    if [ "$failed" = true ]; then
+        return 1
+    fi
+    return 0
+}
+
+# ============================================================================
+# INSTALL FUNCTIONS
+# ============================================================================
+
+install_mapt() {
+    local arch
+    arch=$(mapt_arch)
+
+    log "Installing mapt v${MAPT_VERSION} for Linux $arch..."
+
+    verify_linux || return 1
+    mkdir -p "$TMP_DIR"
+
+    local download_url="https://github.com/redhat-developer/mapt/releases/download/v${MAPT_VERSION}/mapt-linux-${arch}"
+    local checksums_url="https://github.com/redhat-developer/mapt/releases/download/v${MAPT_VERSION}/mapt-checksums.txt"
+
+    log "Downloading from: $download_url"
+    curl -fsSL "$download_url" -o "${TMP_DIR}/mapt"
+    curl -fsSL "$checksums_url" -o "${TMP_DIR}/mapt-checksums.txt"
+
+    log "Verifying checksum..."
+    local expected
+    expected=$(grep "mapt-linux-${arch}" "${TMP_DIR}/mapt-checksums.txt" | awk '{print $1}')
+    local actual
+    actual=$(sha256sum "${TMP_DIR}/mapt" | awk '{print $1}')
+    if [ "$expected" != "$actual" ]; then
+        log "✗ Checksum mismatch for mapt-linux-${arch}" >&2
+        log "  Expected: $expected" >&2
+        log "  Actual:   $actual" >&2
+        return 1
+    fi
+    log "✓ Checksum verified"
+
+    chmod +x "${TMP_DIR}/mapt"
+
+    log "Installing to: $INSTALL_DIR"
+    if [ "$INSTALL_DIR" = "/usr/local/bin" ]; then
+        maybe_sudo mv "${TMP_DIR}/mapt" "$INSTALL_DIR/mapt"
+    else
+        mv "${TMP_DIR}/mapt" "$INSTALL_DIR/mapt"
+    fi
+
+    echo "$MAPT_VERSION" > "$INSTALL_DIR/mapt.version"
+
+    if check_mapt; then
+        log "✓ mapt installed successfully"
+        return 0
+    else
+        log "✗ mapt installation verification failed" >&2
+        return 1
+    fi
+}
+
+install_pulumi() {
+    local arch
+    arch=$(pulumi_arch)
+
+    log "Installing pulumi v${PULUMI_VERSION} for Linux $arch..."
+
+    verify_linux || return 1
+
+    if ! command_exists tar; then
+        log "ERROR: tar is required but not installed" >&2
+        return 1
+    fi
+
+    mkdir -p "$TMP_DIR"
+    pushd "$TMP_DIR" >/dev/null
+
+    local download_url="https://github.com/pulumi/pulumi/releases/download/v${PULUMI_VERSION}/pulumi-v${PULUMI_VERSION}-linux-${arch}.tar.gz"
+    local checksums_url="https://get.pulumi.com/releases/sdk/pulumi-${PULUMI_VERSION}-checksums.txt"
+
+    log "Downloading from: $download_url"
+    curl -fsSL "$download_url" -o "pulumi.tar.gz"
+    curl -fsSL "$checksums_url" -o "pulumi-checksums.txt"
+
+    log "Verifying checksum..."
+    local filename="pulumi-v${PULUMI_VERSION}-linux-${arch}.tar.gz"
+    local expected
+    expected=$(grep "$filename" "pulumi-checksums.txt" | awk '{print $1}')
+    local actual
+    actual=$(sha256sum "pulumi.tar.gz" | awk '{print $1}')
+    if [ "$expected" != "$actual" ]; then
+        log "✗ Checksum mismatch for $filename" >&2
+        log "  Expected: $expected" >&2
+        log "  Actual:   $actual" >&2
+        return 1
+    fi
+    log "✓ Checksum verified"
+
+    log "Extracting..."
+    tar -xzf "pulumi.tar.gz"
+
+    log "Installing to: $INSTALL_DIR"
+    if [ "$INSTALL_DIR" = "/usr/local/bin" ]; then
+        maybe_sudo mv pulumi/pulumi "$INSTALL_DIR/pulumi"
+    else
+        mv pulumi/pulumi "$INSTALL_DIR/pulumi"
+    fi
+
+    popd >/dev/null
+
+    if check_pulumi; then
+        log "✓ pulumi installed successfully"
+        return 0
+    else
+        log "✗ pulumi installation verification failed" >&2
+        return 1
+    fi
+}
+
+install_pulumi_providers() {
+    log "Installing pulumi provider plugins..."
+
+    pulumi plugin install --exact resource aws "$PULUMI_AWS_VERSION" \
+        && pulumi plugin install --exact resource awsx "$PULUMI_AWSX_VERSION" \
+        && pulumi plugin install --exact resource azure-native "$PULUMI_AZURE_NATIVE_VERSION" \
+        && pulumi plugin install --exact resource command "$PULUMI_COMMAND_VERSION" \
+        && pulumi plugin install --exact resource tls "$PULUMI_TLS_VERSION" \
+        && pulumi plugin install --exact resource random "$PULUMI_RANDOM_VERSION" \
+        && pulumi plugin install --exact resource aws-native "$PULUMI_AWS_NATIVE_VERSION" \
+        && pulumi plugin install --exact resource gitlab "$PULUMI_GITLAB_VERSION"
+
+    if check_pulumi_providers; then
+        log "✓ All pulumi providers installed successfully"
+        return 0
+    else
+        log "✗ Pulumi provider installation verification failed" >&2
+        return 1
+    fi
+}
+
+# ============================================================================
+# MAIN SCRIPT
+# ============================================================================
+
+main() {
+    local check_only=false
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -c|--check)
+                check_only=true
+                shift
+                ;;
+            *)
+                log "ERROR: Unknown option: $1" >&2
+                log "Usage: $(basename "$0") [--check]" >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    mkdir -p "$INSTALL_DIR"
+    mkdir -p "$TMP_DIR"
+
+    export PATH="$INSTALL_DIR:$PATH"
+    warn_if_not_in_path "$INSTALL_DIR"
+
+    if [ "$check_only" = true ]; then
+        check_all
+        exit $?
+    fi
+
+    if ! check_mapt; then
+        echo ""
+        log "Installing mapt..."
+        install_mapt
+    fi
+
+    if ! check_pulumi; then
+        echo ""
+        log "Installing pulumi..."
+        install_pulumi
+    fi
+
+    if ! check_pulumi_providers; then
+        echo ""
+        log "Installing pulumi providers..."
+        install_pulumi_providers
+    fi
+
+    log ""
+    log "✓ All mapt dependencies installed successfully"
+}
+
+main "$@"


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/AIPCC-3491

## Summary

- Add `mapt-provisioner` skill for provisioning cloud machines via [mapt](https://github.com/redhat-developer/mapt). Initial targets: RHELAI (AWS + Azure) and OpenShift SNC (AWS only).
- Add `tools/mapt/install.sh` to install mapt binary, pulumi CLI, and 8 pulumi provider plugins with Renovate-tracked versions.
- SKILL.md includes safety gates: mandatory `MAPT_BACKEND_URL` for persistent state (prevents orphaning billable cloud resources), destroy confirmation, GPU cost warnings, and a structured error handling table.
- Scripts handle credential validation, spot instances, GPU accelerators (cuda/rocm), disk sizing, cost attribution tags, and `--force-destroy` for stale Pulumi locks.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive MAPT provisioner docs: workflows, env vars per target, safety rules, command templates, verification steps, connection-details handling, and troubleshooting.

* **New Features**
  * CLI provisioning for RHEL AI and OpenShift SNC (AWS/Azure) with sizing, GPUs/accelerators, spot, tags, versioning, and connection-output.
  * Status-check and destroy CLIs with confirmation and controlled force-destroy.
  * Shared helper utilities for validation and connection logging.
  * Automatic installer to verify/install MAPT, Pulumi, and provider plugins (with checksum checks).
  * Azure RHEL AI version discovery tool.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aipcc-cicd/claudio-skills/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->