### PR TITLE
feat: automate releases via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,36 +1,96 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v0.5.6)'
+        required: true
+        type: string
+
+permissions: {}
 
 jobs:
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-24.04
+    environment: release
+    steps:
+    - name: Verify team membership
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        ACTOR: ${{ github.actor }}
+      run: |
+        gh api "orgs/aipcc-cicd/teams/aipcc-productization/memberships/${ACTOR}" --silent \
+          || (echo "::error::${ACTOR} is not a member of aipcc-cicd/aipcc-productization" && exit 1)
+
   release:
     name: Create Release
+    needs: authorize
     runs-on: ubuntu-24.04
+    environment: release
     permissions:
       contents: write
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+    - name: Validate version format
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        if [[ ! "${INPUT_VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+          echo "::error::Invalid version '${INPUT_VERSION}'. Expected format: v0.5.6 or v0.5.6-rc1"
+          exit 1
+        fi
 
-      - name: Verify tag is on main or release branch
-        run: |
-          git branch -r --contains ${{ github.sha }} | grep -qE 'origin/main|origin/release-' || \
-            (echo "Tag is not on main or a release branch" && exit 1)
+    - name: Check release does not exist
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        if gh release view "${INPUT_VERSION}" &>/dev/null; then
+          echo "::error::Release ${INPUT_VERSION} already exists"
+          exit 1
+        fi
 
-      - name: Extract version from tag
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.RELEASE_PAT }}
 
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "v${{ env.VERSION }}" \
-            --title "Release v${{ env.VERSION }}" \
-            --generate-notes
+    - name: Compute version strings
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        TAG="${INPUT_VERSION}"
+        VERSION="${TAG#v}"
+        echo "TAG=${TAG}" >> $GITHUB_ENV
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+    - name: Update plugin.json version
+      run: |
+        cd claudio-plugin/.claude-plugin
+        jq --arg v "$VERSION" '.version = $v' plugin.json > plugin.json.tmp
+        mv plugin.json.tmp plugin.json
+
+    - name: Update README badge
+      run: |
+        sed -i "s/version-[0-9]*\.[0-9]*\.[0-9]*/version-${VERSION}/" README.md
+
+    - name: Commit version bump
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add claudio-plugin/.claude-plugin/plugin.json README.md
+        git commit -m "chore(release): ${TAG}"
+        git push origin HEAD
+        echo "RELEASE_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+    - name: Create release and tag
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        RELEASE_TAG: ${{ inputs.version }}
+      run: |
+        gh release create "${RELEASE_TAG}" \
+          --target "${RELEASE_SHA}" \
+          --title "${RELEASE_TAG}" \
+          --generate-notes

--- a/README.md
+++ b/README.md
@@ -411,6 +411,24 @@ When using this plugin you typically want to allow skill scripts to run without 
 - Add new `Skill(...)` entries incrementally as domain skills are deployed
 - `Read(/home/$USER/.claude/**)` — allows reading Claude config files (CLAUDE.md, memory files)
 
+## Releasing
+
+Releases are fully automated via GitHub Actions — no manual commits or version bumps needed.
+
+1. Go to **Actions** → **Release** → **Run workflow**
+2. Enter the version (e.g. `v0.5.6`)
+3. Click **Run workflow**
+
+The workflow validates the version format, bumps `plugin.json` and the README badge, commits to `main`, creates a git tag, and publishes a GitHub Release with auto-generated notes.
+
+### Patch releases
+
+If you need to patch an older release:
+
+1. Create a release branch from the tag: `git checkout -b release-0.5 v0.5.6`
+2. Cherry-pick the fix(es) and push the branch: `git push origin release-0.5`
+3. Run the release workflow, selecting the release branch as the target
+
 ## Contributing
 
 Contributions are welcome! Please:


### PR DESCRIPTION
## Summary

- Replace tag-triggered release workflow with `workflow_dispatch` — enter version (e.g. `v0.5.6`) and click Run
- Workflow automatically bumps `plugin.json` + README badge, commits, creates tag + GitHub Release
- Eliminates manual `chore(cut)` commits

## How it works

1. Trigger: Actions → Release → Run workflow → enter `v0.5.6`
2. Workflow updates `plugin.json` version and README badge
3. Commits `chore(release): v0.5.6` to main
4. Creates git tag `v0.5.6` + GitHub Release with auto-generated notes

Companion to aipcc-cicd/claudio#151 which does the same for the base image.

## Test plan

- [ ] Verify workflow syntax renders correctly in Actions tab
- [ ] Dry-run with a test version (e.g. `v0.5.6-rc1`)
- [ ] Verify plugin.json and README are updated in the commit
- [ ] Verify tag and release are created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)