### PR TITLE
fix(release): remove duplicate environment gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
     name: Create Release
     needs: authorize
     runs-on: ubuntu-24.04
-    environment: release
     permissions:
       contents: write
 

--- a/claudio-plugin/tools/kustomize/install.sh
+++ b/claudio-plugin/tools/kustomize/install.sh
@@ -23,9 +23,8 @@ source "$SCRIPT_DIR/../common.sh"
 # ============================================================================
 # DEPENDENCY VERSION
 # ============================================================================
-# This version is tracked by Renovate for automatic updates
-# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=regex:^kustomize/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
-KUSTOMIZE_VERSION="5.8.1"
+# Pinned to match KRD — bump manually when KRD bumps
+KUSTOMIZE_VERSION="5.7.1"
 
 # ============================================================================
 # CONFIGURATION


### PR DESCRIPTION
## Summary
- Removed `environment: release` from the `release` job — it was causing a second approval prompt. The `authorize` job already gates on the environment; the `release` job only needs `RELEASE_PAT` (now an org-level secret)
- Pinned kustomize to v5.7.1 to match KRD and removed Renovate tracking — bump manually when KRD upgrades

## Test plan
- [ ] Trigger release workflow and confirm only one approval prompt appears (on Authorize)
- [ ] Verify kustomize installs v5.7.1 in the container image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted release workflow permissions to explicitly grant required write access during release jobs.
  * Updated the bundled installer to use Kustomize v5.7.1 (pins the downloadable archive and version checks), affecting tool installation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aipcc-cicd/claudio-skills/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->