### PR TITLE
fix(release): use GITHUB_TOKEN for release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Check release does not exist
       env:
-        GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         INPUT_VERSION: ${{ inputs.version }}
       run: |
         if gh release view "${INPUT_VERSION}" &>/dev/null; then
@@ -55,7 +55,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
       with:
-        token: ${{ secrets.RELEASE_PAT }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Compute version strings
       env:
@@ -87,7 +87,7 @@ jobs:
 
     - name: Create release and tag
       env:
-        GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_TAG: ${{ inputs.version }}
       run: |
         gh release create "${RELEASE_TAG}" \


### PR DESCRIPTION
## Summary
- Switch release job from `RELEASE_PAT` to `GITHUB_TOKEN` so releases are attributed to `github-actions[bot]` instead of the triggering user
- `RELEASE_PAT` stays only on the authorize job for the org team membership check

## Test plan
- [ ] Trigger release workflow and confirm the GitHub Release is authored by `github-actions[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow authentication to use built-in GitHub token, streamlining the release creation process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aipcc-cicd/claudio-skills/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->