### PR TITLE
fix(release): use RELEASE_PAT for checkout to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.RELEASE_PAT }}
 
     - name: Compute version strings
       env:


### PR DESCRIPTION
## Problem

The v0.6.3 release failed because the checkout step was switched from `RELEASE_PAT` to `GITHUB_TOKEN` in commit 351344b. `GITHUB_TOKEN` cannot bypass the branch protection rule on `main` that requires changes via pull request, so the version-bump push is rejected:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
! [remote rejected] HEAD -> main (protected branch hook declined)
```

## Fix

Use `RELEASE_PAT` for the checkout step (so the push can bypass branch protection), while keeping `GITHUB_TOKEN` for `gh release create` (so the release is still attributed to `github-actions[bot]`).

## Why not just allow GITHUB_TOKEN to bypass?

The repo uses legacy branch protection rules which don't support bypass actors. Switching to repository rulesets would work but is a bigger change affecting the whole protection model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow authentication configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->