### PR TITLE
AIPCC-18826: Extend jira-utilities for readiness-detector

### DIFF
--- a/claudio-plugin/skills/jira-utilities/scripts/create_issue.sh
+++ b/claudio-plugin/skills/jira-utilities/scripts/create_issue.sh
@@ -18,6 +18,8 @@
 #   --component c1,c2     Comma-separated component names
 #   --team UUID           Team UUID for customfield_10001 (not display name)
 #   --epic KEY            Parent epic key (e.g., PROJ-42)
+#   --epic-link-field ID  Custom field ID for epic link (used with --epic)
+#   --security NAME       Security level name (e.g., "Red Hat Employee")
 #   --activity-type TYPE  One of: "Tech Debt & Quality" | "New Features" | "Learning & Enablement"
 #
 # Output: JSON with the created issue key
@@ -36,6 +38,8 @@ ASSIGNEE=""
 COMPONENT=""
 TEAM=""
 EPIC=""
+EPIC_LINK_FIELD_ID=""
+SECURITY=""
 ACTIVITY_TYPE=""
 
 if [[ $# -lt 2 ]]; then
@@ -56,6 +60,8 @@ while [[ $# -gt 0 ]]; do
         --component)     COMPONENT="$2";      shift 2 ;;
         --team)          TEAM="$2";           shift 2 ;;
         --epic)          EPIC="$2";           shift 2 ;;
+        --epic-link-field) EPIC_LINK_FIELD_ID="$2"; shift 2 ;;
+        --security)      SECURITY="$2";       shift 2 ;;
         --activity-type) ACTIVITY_TYPE="$2";  shift 2 ;;
         *) echo "ERROR: Unknown option: $1" >&2; exit 1 ;;
     esac
@@ -93,18 +99,29 @@ if [[ -n "$DESCRIPTION" ]]; then
     JSON=$(echo "$JSON" | jq --argjson v "$ADF" '. + {description: $v}')
 fi
 [[ -n "$ASSIGNEE" ]]    && JSON=$(echo "$JSON" | jq --arg v "$ASSIGNEE"    '. + {assignee: $v}')
-[[ -n "$EPIC" ]]        && JSON=$(echo "$JSON" | jq --arg v "$EPIC"        '. + {parentIssueId: $v}')
+
+# ---- additionalAttributes for fields acli does not expose as flags ----
+EXTRA="{}"
+
+if [[ -n "$EPIC" ]]; then
+    if [[ -n "$EPIC_LINK_FIELD_ID" ]]; then
+        EXTRA=$(echo "$EXTRA" | jq --arg field "$EPIC_LINK_FIELD_ID" --arg v "$EPIC" \
+            '. + {($field): $v}')
+    else
+        JSON=$(echo "$JSON" | jq --arg v "$EPIC" '. + {parentIssueId: $v}')
+    fi
+fi
 
 if [[ -n "$LABELS" ]]; then
     LABELS_JSON=$(printf '%s' "$LABELS" | jq -R 'split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | map(select(. != ""))')
     JSON=$(echo "$JSON" | jq --argjson v "$LABELS_JSON" '. + {label: $v}')
 fi
 
-# ---- additionalAttributes for fields acli does not expose as flags ----
-EXTRA="{}"
-
 [[ -n "$PRIORITY" ]] && EXTRA=$(echo "$EXTRA" | jq --arg v "$PRIORITY" \
     '. + {priority: {name: $v}}')
+
+[[ -n "$SECURITY" ]] && EXTRA=$(echo "$EXTRA" | jq --arg v "$SECURITY" \
+    '. + {security: {name: $v}}')
 
 if [[ -n "$COMPONENT" ]]; then
     COMP_JSON=$(printf '%s' "$COMPONENT" | jq -R 'split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | map(select(. != "")) | map({name: .})')

--- a/claudio-plugin/skills/jira-utilities/scripts/get_issue_comments.sh
+++ b/claudio-plugin/skills/jira-utilities/scripts/get_issue_comments.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Fetch comments for a Jira issue.
+#
+# Usage:
+#   ./get_issue_comments.sh <issue_key>
+#
+# Example:
+#   ./get_issue_comments.sh PROJ-123
+#
+# Output: JSON array of comment objects
+# Exit codes: 0=success, 1=invalid params
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $(basename "$0") <issue_key>" >&2
+    exit 1
+fi
+
+KEY="$1"
+
+if [[ ! "$KEY" =~ ^[A-Z][A-Z0-9_]+-[0-9]+$ ]]; then
+    echo "ERROR: Invalid issue key format: '$KEY' (expected e.g. PROJ-123)" >&2
+    exit 1
+fi
+
+require_env
+
+echo "Fetching comments for $KEY..." >&2
+jira_rest GET "/rest/api/2/issue/${KEY}/comment" \
+    | jq '.comments'


### PR DESCRIPTION
Add --security and --epic-link-field options to create_issue.sh, and add new get_issue_comments.sh script for fetching issue comments via REST API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new command to fetch and display comments for a specified Jira issue key.
  * Expanded issue creation options to support setting a security level and linking epic issues via a configurable custom field.
* **Bug Fixes**
  * Improved epic linking behavior to work across more Jira configurations by using the custom field when provided, and falling back to the prior epic relationship method otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->