### PR TITLE
AIPCC-18826: Fix update_issue.sh and search_issues.sh for acli compat…

### DIFF
--- a/claudio-plugin/skills/jira-utilities/scripts/create_issue.sh
+++ b/claudio-plugin/skills/jira-utilities/scripts/create_issue.sh
@@ -114,7 +114,7 @@ fi
 
 if [[ -n "$LABELS" ]]; then
     LABELS_JSON=$(printf '%s' "$LABELS" | jq -R 'split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | map(select(. != ""))')
-    JSON=$(echo "$JSON" | jq --argjson v "$LABELS_JSON" '. + {label: $v}')
+    JSON=$(echo "$JSON" | jq --argjson v "$LABELS_JSON" '. + {labels: $v}')
 fi
 
 [[ -n "$PRIORITY" ]] && EXTRA=$(echo "$EXTRA" | jq --arg v "$PRIORITY" \

--- a/claudio-plugin/skills/jira-utilities/scripts/search_issues.sh
+++ b/claudio-plugin/skills/jira-utilities/scripts/search_issues.sh
@@ -97,8 +97,8 @@ fi
 # Bug 3: acli rejects --fields entirely in table mode; skip it with a warning.
 if [[ -n "$FIELDS" && "$FORMAT" != "table" ]]; then
     DATE_FIELDS_PATTERN="^(created|updated|resolutiondate|updateddate|createddate)$"
-    SAFE_FIELDS=$(echo "$FIELDS" | tr ',' '\n' | grep -Eiv "$DATE_FIELDS_PATTERN" | paste -sd ',' -)
-    DATE_ONLY_FIELDS=$(echo "$FIELDS" | tr ',' '\n' | grep -Ei "$DATE_FIELDS_PATTERN" | paste -sd ',' -)
+    SAFE_FIELDS=$(echo "$FIELDS" | tr ',' '\n' | { grep -Eiv "$DATE_FIELDS_PATTERN" || true; } | paste -sd ',' -)
+    DATE_ONLY_FIELDS=$(echo "$FIELDS" | tr ',' '\n' | { grep -Ei "$DATE_FIELDS_PATTERN" || true; } | paste -sd ',' -)
     if [[ -n "$DATE_ONLY_FIELDS" ]]; then
         echo "WARN: acli does not support --fields $DATE_ONLY_FIELDS; timestamps are available in the JSON payload via .fields.created / .fields.updated." >&2
     fi

--- a/claudio-plugin/skills/jira-utilities/scripts/update_issue.sh
+++ b/claudio-plugin/skills/jira-utilities/scripts/update_issue.sh
@@ -64,12 +64,32 @@ ensure_auth
 JSON="{}"
 
 [[ -n "$SUMMARY" ]]     && JSON=$(echo "$JSON" | jq --arg v "$SUMMARY"     '. + {summary: $v}')
-[[ -n "$DESCRIPTION" ]] && JSON=$(echo "$JSON" | jq --arg v "$DESCRIPTION" '. + {description: $v}')
+if [[ -n "$DESCRIPTION" ]]; then
+    ADF=$(jq -n --arg text "$DESCRIPTION" '{
+        type: "doc",
+        version: 1,
+        content: [{
+            type: "paragraph",
+            content: [{ type: "text", text: $text }]
+        }]
+    }')
+    JSON=$(echo "$JSON" | jq --argjson v "$ADF" '. + {description: $v}')
+fi
 [[ -n "$ASSIGNEE" ]]    && JSON=$(echo "$JSON" | jq --arg v "$ASSIGNEE"    '. + {assignee: $v}')
 
 if [[ -n "$LABELS" ]]; then
-    LABELS_JSON=$(printf '%s' "$LABELS" | jq -R 'split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | map(select(. != ""))')
-    JSON=$(echo "$JSON" | jq --argjson v "$LABELS_JSON" '. + {labels: $v}')
+    DESIRED_JSON=$(printf '%s' "$LABELS" | jq -R 'split(",") | map(ltrimstr(" ") | rtrimstr(" ")) | map(select(. != ""))')
+    # Fetch current labels to compute add/remove diff (acli uses labelsToAdd/labelsToRemove)
+    CURRENT_RAW=$(acli jira workitem view "$KEY" --fields labels --json 2>/dev/null || echo "{}")
+    CURRENT_JSON=$(printf '%s' "$CURRENT_RAW" | jq -r 'if type == "array" then (.[0].fields.labels // []) else (.fields.labels // []) end' 2>/dev/null || echo "[]")
+    LABELS_TO_ADD=$(jq -n --argjson d "$DESIRED_JSON" --argjson c "$CURRENT_JSON" \
+        '[$d[] | select(. as $l | $c | index($l) | not)]')
+    LABELS_TO_REMOVE=$(jq -n --argjson d "$DESIRED_JSON" --argjson c "$CURRENT_JSON" \
+        '[$c[] | select(. as $l | $d | index($l) | not)]')
+    [[ $(printf '%s' "$LABELS_TO_ADD"    | jq 'length') -gt 0 ]] && \
+        JSON=$(echo "$JSON" | jq --argjson v "$LABELS_TO_ADD"    '. + {labelsToAdd: $v}')
+    [[ $(printf '%s' "$LABELS_TO_REMOVE" | jq 'length') -gt 0 ]] && \
+        JSON=$(echo "$JSON" | jq --argjson v "$LABELS_TO_REMOVE" '. + {labelsToRemove: $v}')
 fi
 
 # ---- additionalAttributes for priority (not exposed by acli edit) ----
@@ -78,12 +98,14 @@ if [[ -n "$PRIORITY" ]]; then
         '. + {additionalAttributes: {priority: {name: $v}}}')
 fi
 
-# ---- Write temp file and edit via acli ----
+# ---- Include key in JSON (acli requires issues array, not key field) ----
+JSON=$(echo "$JSON" | jq --arg k "$KEY" '. + {issues: [$k]}')
+
 TMPFILE=$(make_tmp_json "$JSON")
-trap "rm -f $TMPFILE" EXIT
+trap 'rm -f "$TMPFILE"' EXIT
 
 echo "Updating $KEY..." >&2
-acli jira workitem edit --key "$KEY" --from-json "$TMPFILE" --json --yes
+acli jira workitem edit --from-json "$TMPFILE" --json --yes
 
 echo "Updated: $KEY" >&2
 echo "{\"updated\": \"$KEY\"}"


### PR DESCRIPTION
…ibility

Three fixes needed for the readiness-detector's Jira round-trip to work:
- update_issue.sh: use issues array instead of key field, wrap description in ADF paragraph node (acli requires this format for both)
- update_issue.sh: acli's --from-json labels field requires a diff (labelsToAdd/labelsToRemove), not a full replacement list. Fetch current labels first and compute the add/remove sets.
- search_issues.sh: grep -Ei against DATE_FIELDS_PATTERN exits 1 when no field matches (e.g. --fields labels). Under set -euo pipefail this crashed the whole script, silently dropping --fields and returning empty output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Issue updates now preserve existing labels by adding and removing only the label differences, rather than replacing labels wholesale.
  * Issue descriptions are now submitted in Jira-compatible ADF JSON for more reliable edits.
  * Issue search no longer fails when no date-type fields match, safely handling empty results.
  * New issues now set labels using Jira’s expected multi-label structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->