### PR TITLE
AIPCC-18826: Fix PR #72 review follow-ups in jira-utilities

### DIFF
--- a/claudio-plugin/skills/jira-utilities/scripts/create_issue.sh
+++ b/claudio-plugin/skills/jira-utilities/scripts/create_issue.sh
@@ -140,7 +140,7 @@ fi
 
 # ---- Write temp file and create via acli ----
 TMPFILE=$(make_tmp_json "$JSON")
-trap "rm -f $TMPFILE" EXIT
+trap 'rm -f "$TMPFILE"' EXIT
 
 echo "Creating $ISSUETYPE in $PROJECT: '$SUMMARY'..." >&2
 acli jira workitem create --from-json "$TMPFILE" --json

--- a/claudio-plugin/skills/jira-utilities/scripts/update_issue.sh
+++ b/claudio-plugin/skills/jira-utilities/scripts/update_issue.sh
@@ -14,7 +14,8 @@
 #   --description TEXT  New description
 #   --priority NAME     New priority (e.g., Critical, High, Medium, Low)
 #   --assignee ID       New assignee account ID or email
-#   --labels l1,l2      New labels, comma-separated (replaces existing)
+#   --labels l1,l2      New labels, comma-separated (diffs against current;
+#                       adds missing, removes unlisted)
 #
 # Output: JSON {"updated": "<issue_key>"}
 # Exit codes: 0=success, 1=invalid params, 2=API error, 4=auth error


### PR DESCRIPTION
Single-quote trap in create_issue.sh to defer $TMPFILE expansion (SC2064), and update stale --labels usage comment in update_issue.sh to reflect the diff-based behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary file cleanup to be safer at script exit.
* **Documentation**
  * Clarified the `--labels` option so it now explains that labels are compared against existing ones, with only missing labels added and unlisted ones removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->