### PR TITLE
feat(skills): add package-request skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Claudio Skills Plugin provides five production-ready skills designed to streamli
 - **GitLab Branch Management** - Create and protect GitLab branches with configurable protection rules
 - **Jira Utilities** - Manage Jira issues with JQL search, create/update issues, link issues, and fetch sprint info
 - **Mapt Provisioner** - Provision and manage cloud infrastructure using mapt (RHEL AI on AWS/Azure, OpenShift SNC on AWS, spot instances, GPU workloads)
+- **Package Request** - Submit package onboarding requests, creating Jira epics and triggering onboarding pipelines
 
 ## Skills
 
@@ -163,6 +164,24 @@ Provision and manage cloud VMs and services on AWS and Azure using [mapt](https:
 - `JIRA_TOKEN` - API token (Cloud) or Personal Access Token (Data Center)
 - `JIRA_EMAIL` - User email (Cloud auth only)
 - `JIRA_AUTH_TYPE` - `cloud` or `datacenter` (default: `cloud`)
+
+### 8. Package Request Skill
+
+Submit package onboarding requests — creates Jira epics and triggers the onboarding pipeline.
+
+**Use Cases:**
+- Request a new Python package for inclusion in RHEL AI / RHAIIS builds
+- Guided collection of required fields (package name, team, justification, timeline)
+- Handle production-repo warnings and duplicate request detection
+
+**Key Features:**
+- Conversational flow that collects fields one at a time or all at once
+- Validates packages on PyPI, checks for duplicates, warns on production repo conflicts
+- Triggers the package-onboarding GitLab pipeline automatically
+
+**Prerequisites:**
+- `curl`, `jq`, `glab`
+- `JIRA_SITE`, `JIRA_TOKEN`, `JIRA_EMAIL`, `GITLAB_TOKEN`
 
 ## Installation
 ### Prerequisites

--- a/claudio-plugin/skills/jira-utilities/scripts/_common.sh
+++ b/claudio-plugin/skills/jira-utilities/scripts/_common.sh
@@ -53,7 +53,7 @@ jira_site_url() {
 
 # Escape a value for embedding in a JQL string literal (doubles embedded double-quotes).
 # Usage: escaped=$(jql_escape "value with \"quotes\"")
-jql_escape() { printf '%s' "${1//\"/\\\"}"; }
+jql_escape() { local s="${1//\\/\\\\}"; printf '%s' "${s//\"/\\\"}"; }
 
 # Make a Jira REST API call.
 # Usage: jira_rest GET|POST|PUT|DELETE <path> [json_body]

--- a/claudio-plugin/skills/package-request/README.md
+++ b/claudio-plugin/skills/package-request/README.md
@@ -1,0 +1,78 @@
+# Package Request Skill
+
+Submit package onboarding requests directly via Jira REST API and GitLab CI. Creates a Jira epic with security level "Red Hat Employee" and triggers the package-onboarding pipeline.
+
+## Quick Start
+
+Tell Claude to request a package:
+
+```text
+Request the torch package with cuda extras for AIPCC-12345
+```
+
+Or provide everything upfront:
+
+```text
+Submit a package request:
+- Package: torch[cuda]
+- Requester: rkothari@redhat.com
+- Jira project: RHAISTRAT
+- Team: Accelerator Enablement
+- Related ticket: AIPCC-12345
+- Justification: Needed for training pipeline support
+- Delivery timeline: 2026-08-01
+```
+
+Claude will collect any missing fields, confirm the submission, and return the Jira ticket link.
+
+## Fields
+
+### Required
+
+| Field | Description |
+|---|---|
+| Package name | Python package name (e.g. `torch`, `torch[cuda]`). No version specifiers. |
+| Requester | Email, kerberos ID, or display name. Must exist in Jira. |
+| Jira project | `RHAISTRAT` or `AIPCC` — determines available teams. |
+| Team | Component from the selected Jira project. Claude fetches options from Jira. |
+| Related Jira ticket | Format: `PROJECT-NUMBER` (e.g. `AIPCC-12345`). |
+| Business justification | Why this package is needed (10-5000 chars). |
+| Delivery timeline | Target date in ISO format (YYYY-MM-DD), at least 8 days from today. |
+
+### Optional
+
+| Field | Description |
+|---|---|
+| Extras | Comma-separated PEP 508 identifiers (e.g. `cuda,tensor`). |
+| Package source | `pypi` (default), `git`, or `other`. |
+| Source URL | Required when source is `git` or `other`. |
+| Version | PEP 440 specifier (e.g. `>=2.0.0`, `~=1.4`). |
+| Backport versions | Stable series to backport to (e.g. `3.4,3.5-EA1`). |
+| Release targets | Target product versions (e.g. `RHAI 3.6,RHAIIS 3.4`). |
+| Release commitment | Free text, max 2000 chars. |
+| Hardware requirements | Free text, max 500 chars. |
+| Testing requirements | Free text, max 2000 chars. |
+
+## Configuration
+
+| Variable | Required | Description |
+|---|---|---|
+| `JIRA_SITE` | Yes | Atlassian site hostname (e.g. `redhat.atlassian.net`) |
+| `JIRA_TOKEN` | Yes | Atlassian API token |
+| `JIRA_EMAIL` | Yes | Atlassian account email |
+| `GITLAB_TOKEN` | No | GitLab personal access token with `api` scope (pipeline trigger is skipped without it) |
+| `JIRA_PROJECT` | No | Jira project key (default: `AIPCC`) |
+| `JIRA_COMPONENT` | No | Component set on created epics (default: `Accelerator Enablement`) |
+
+## What Happens After Submission
+
+1. Creates a Jira epic in the selected project with security level "Red Hat Employee"
+2. Best-effort triggers the `package-onboarding` GitLab pipeline via `glab ci run` (skipped if `GITLAB_TOKEN` or `glab` is unavailable; trigger failures are warnings, not errors)
+3. If triggered, the pipeline runs security checks, builds, and creates child stories (QE testing, RHAI pipeline onboarding)
+
+## Troubleshooting
+
+- **Missing env vars**: Ensure `JIRA_SITE`, `JIRA_TOKEN`, `JIRA_EMAIL`, and `GITLAB_TOKEN` are set.
+- **Pipeline trigger fails**: Verify `GITLAB_TOKEN` has `api` scope (not just `read_api`).
+- **TLS errors in claudio container**: Install the Red Hat CA bundle via `tools/redhat-ca/install.sh`.
+- **Validation errors**: Check that the requester exists in Jira and the delivery date is at least 8 days out.

--- a/claudio-plugin/skills/package-request/SKILL.md
+++ b/claudio-plugin/skills/package-request/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: package-request
+description: Submit a package onboarding request — creates a Jira epic and triggers the onboarding pipeline. Use when the user asks to request a package, onboard a package, or submit a package request.
+compatibility: Requires jq, curl, and glab. Requires JIRA_SITE, JIRA_TOKEN, JIRA_EMAIL, and GITLAB_TOKEN environment variables.
+allowed-tools: Bash(*/package-request/scripts/submit.sh *),Bash(*/package-request/scripts/list_teams.sh *),Bash(*/tools/*/install.sh *)
+---
+
+# Package Request
+
+Submit package onboarding requests. Creates a Jira epic and triggers the package-onboarding GitLab pipeline.
+
+## Prerequisites
+
+- `jq` — JSON processor (install via `../../../tools/jq/install.sh`)
+- `curl` — HTTP client (typically pre-installed)
+- `glab` — GitLab CLI (install via `../../../tools/glab/install.sh`)
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `JIRA_SITE` | (required) | Atlassian site hostname (e.g. `redhat.atlassian.net`) |
+| `JIRA_TOKEN` | (required) | Atlassian API token |
+| `JIRA_EMAIL` | (required) | Atlassian account email |
+| `GITLAB_TOKEN` | (required) | GitLab personal access token for pipeline trigger |
+| `JIRA_PROJECT` | `AIPCC` | Jira project key for epic creation |
+| `JIRA_COMPONENT` | `Accelerator Enablement` | Component set on created epics |
+
+## Interaction Flow
+
+Follow these steps precisely:
+
+### Step 1: Parse user input
+
+Extract any fields the user provided upfront. The user may provide anywhere from zero to all fields. Map what they gave to the fields below.
+
+**Required fields** (must collect all before submitting):
+
+| Field | Arg name | Type | Constraints |
+|---|---|---|---|
+| Package name | `--package-name` | string | 1-255 chars, no version specifiers (`=<>!~`). Extras syntax is ok (e.g. `torch[cuda]`) |
+| Requester | `--requester` | string | Email, kerberos ID, or display name. Must exist in Jira |
+| Jira project | *(not sent to script)* | string | `RHAISTRAT` or `AIPCC` — used to fetch team options in Step 2 |
+| Team | `--team` | string | Must be a component from the selected Jira project |
+| Related Jira ticket | `--jira-id` | string | Format: `PROJECT-NUMBER` (e.g. `RHELAI-123`) |
+| Business justification | `--justification` | string | 10-5000 chars |
+| Delivery timeline | `--delivery-timeline` | date | ISO format (YYYY-MM-DD), must be at least 8 days from today |
+
+**Conditionally required:**
+- Source URL (`--source-url`) — required when package source is `git` or `other`
+
+### Step 2: Collect missing required fields
+
+For each missing required field, ask the user one question at a time.
+
+**For the Team field:** fetch available teams first:
+```bash
+${CLAUDE_SKILL_DIR}/scripts/list_teams.sh JIRA_PROJECT
+```
+Replace `JIRA_PROJECT` with the user's selected Jira project (`RHAISTRAT` or `AIPCC`). The script outputs a JSON array of component names. Present them as options for the user to choose from.
+
+**For Delivery timeline:** validate that the date is at least 8 days from today before proceeding.
+
+**For Jira ID:** validate the format matches `PROJECT-NUMBER` (uppercase letters, dash, digits).
+
+### Step 3: Offer optional fields
+
+Once all required fields are collected, tell the user about these optional fields and ask if they want to fill any or proceed:
+
+| Field | Arg name | Notes |
+|---|---|---|
+| Extras | `--extras` | Comma-separated PEP 508 identifiers (e.g. `cuda,tensor`). Also parsed automatically from package name if brackets are present |
+| Package source | `--package-source` | `pypi` (default), `git`, or `other` |
+| Source URL | `--source-url` | Required for git/other sources |
+| Version | `--version` | PEP 440 version or specifier (e.g. `2.0.0`, `>=1.5.0`, `~=1.4`) |
+| Backport versions | `--backport-versions` | Comma-separated stable series (e.g. `3.4,3.5-EA1`) |
+| Release targets | `--release-target` | Comma-separated target product versions (e.g. `RHAI 3.6,RHAIIS 3.4`) |
+| Release commitment | `--release-commitment` | Max 2000 chars |
+| Hardware requirements | `--other-hardware` | Max 500 chars |
+| Testing requirements | `--testing-requirements` | Max 2000 chars |
+
+Backport versions and release targets are free-text — the user types them directly (e.g. `3.4, 3.5-EA1`).
+
+### Step 4: Confirm and submit
+
+Show a summary table of all fields being submitted. Ask for explicit confirmation before proceeding.
+
+Once confirmed, call the submit script:
+
+```bash
+${CLAUDE_SKILL_DIR}/scripts/submit.sh \
+    --package-name "NAME" \
+    --requester "EMAIL" \
+    --team "TEAM" \
+    --jira-id "ID" \
+    --justification "TEXT" \
+    --delivery-timeline "YYYY-MM-DD" \
+    [--extras "a,b,c"] \
+    [--package-source "pypi|git|other"] \
+    [--source-url "URL"] \
+    [--version "VER"] \
+    [--backport-versions "3.4,3.5-EA1"] \
+    [--release-target "RHAI 3.6,RHAIIS 3.4"] \
+    [--release-commitment "TEXT"] \
+    [--other-hardware "TEXT"] \
+    [--testing-requirements "TEXT"]
+```
+
+The script outputs a result type on the first line and JSON on the remaining lines. Parse both.
+
+### Step 5: Handle the response
+
+**`SUCCESS`:**
+Parse the JSON and show:
+- Jira ticket: `ticket_url` (clickable link)
+- Pipeline: `pipeline_url` (if present, clickable link)
+- Package: `package_name`
+
+Example:
+```json
+{"ticket_id":"AIPCC-1234","ticket_url":"https://redhat.atlassian.net/browse/AIPCC-1234","package_name":"torch[cuda]","message":"Package request created successfully","pipeline_url":"https://gitlab.com/..."}
+```
+
+**`PRODUCTION_WARNING`:**
+The package already exists in production repositories. Show the warning details:
+- `details.found_in[].product_version` and `details.found_in[].variant` for each repo
+- `details.found_in[].repo_url` as clickable links
+
+Ask the user: "This package already exists in these production repos. Do you still want to submit the request?"
+
+If yes, re-run the submit script with `--skip-production-check` added.
+
+Example:
+```json
+{"warning":"production_exists","message":"Note: this check does not verify whether the requested extras are available.","details":{"package_name":"torch","found_in":[{"product_version":"3.4","variant":"cpu-ubi9","repo_url":"https://..."}]}}
+```
+
+**`DUPLICATE`:**
+Show the existing tickets from `existing_tickets[]`:
+- `ticket_id` and `ticket_url` for each
+- `summary` for context
+
+Tell the user a similar request was submitted in the past 3 days and show the existing tickets.
+
+Example:
+```json
+{"message":"A request overlapping with '...' was submitted in the past 3 days.","existing_tickets":[{"ticket_id":"AIPCC-1234","ticket_url":"...","summary":"..."}],"total":1}
+```
+
+**`VALIDATION_ERROR`:**
+Parse `message` and tell the user which validation failed and why. Ask them to correct the relevant field, then re-run the submit script with the corrected value.
+
+Example:
+```json
+{"message":"Package 'nonexistent' not found on PyPI. Verify at https://pypi.org/search/?q=nonexistent"}
+```
+
+**Exit code 1 (from script):**
+Invalid parameters. This shouldn't happen if the skill collected all required fields correctly.
+
+**Exit code 2 (from script):**
+A network error occurred (Jira API or curl failure). Suggest retrying.
+
+**Exit code 3 (from script):**
+Missing Jira authentication environment variables. Tell the user to configure `JIRA_SITE`, `JIRA_TOKEN`, and `JIRA_EMAIL`.
+
+### Step 6: Offer to submit another request
+
+After handling the response (success or failure), ask the user if they want to submit another package request. If yes, go back to Step 1. If no, end the conversation.
+
+## Exit Codes (submit.sh)
+
+| Code | Meaning |
+|------|---------|
+| 0 | Result produced (check result type on first line of output) |
+| 1 | Invalid parameters (missing required arguments) |
+| 2 | Network/API error (Jira, curl, or GitLab failure) |
+| 3 | Missing authentication (JIRA_SITE, JIRA_TOKEN, or JIRA_EMAIL not set) |

--- a/claudio-plugin/skills/package-request/scripts/_format.sh
+++ b/claudio-plugin/skills/package-request/scripts/_format.sh
@@ -1,0 +1,103 @@
+# Output helpers, PEP 503 normalization, team label sanitization,
+# and Jira wiki markup description formatting.
+# Sourced by submit.sh — not executed directly.
+
+# ---------------------------------------------------------------------------
+# Output helpers — result type on first line, JSON on remaining
+# ---------------------------------------------------------------------------
+
+output_result() {
+    local type="$1"; shift
+    echo "$type"
+    echo "$@"
+}
+
+output_error() {
+    local type="$1" message="$2"
+    echo "$type"
+    jq -n --arg msg "$message" '{"message": $msg}'
+}
+
+# ---------------------------------------------------------------------------
+# PEP 503 package name normalization
+# ---------------------------------------------------------------------------
+
+normalize_pep503() {
+    echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[-_.]\{1,\}/-/g'
+}
+
+# ---------------------------------------------------------------------------
+# Sanitize team name for Jira label: "AI Core Platform" -> "team-ai-core-platform"
+# ---------------------------------------------------------------------------
+
+sanitize_team_label() {
+    local team="$1"
+    local label
+    label=$(echo "$team" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]\{1,\}/-/g; s/^-//; s/-$//')
+    echo "team-${label}"
+}
+
+# ---------------------------------------------------------------------------
+# Format Jira wiki markup description
+# ---------------------------------------------------------------------------
+
+format_description() {
+    local requester="$1"
+    local team="$2"
+    local pkg_name="$3"
+    local pkg_source="$4"
+    local source_url="$5"
+    local ver="$6"
+    local extras_str="$7"
+    local other_hw="$8"
+    local jira_id="$9"
+    local justification="${10}"
+    local delivery="${11}"
+    local release_commitment="${12}"
+    local testing_req="${13}"
+    local backport_versions="${14}"
+
+    local desc=""
+    desc+="h2. Package Request Details"$'\n'
+    desc+=$'\n'
+    desc+="*Requester:* ${requester}"$'\n'
+    desc+="*Team:* ${team}"$'\n'
+    desc+="*Package Name:* ${pkg_name}"$'\n'
+    desc+="*Package Source:* ${pkg_source:-pypi}"$'\n'
+    desc+="*Source URL:* ${source_url:-N/A}"$'\n'
+    desc+="*Version:* ${ver:-Latest}"$'\n'
+    if [[ -n "$extras_str" ]]; then
+        desc+="*Extras:* ${extras_str}"$'\n'
+    fi
+    desc+="*Hardware Requirements:* ${other_hw:-Standard (all accelerators)}"$'\n'
+    desc+=$'\n'
+    desc+="h2. Business Justification"$'\n'
+    desc+="*Related Jira Ticket:* ${jira_id}"$'\n'
+    desc+=$'\n'
+    desc+="${justification}"$'\n'
+    desc+=$'\n'
+    desc+="h2. Delivery Timeline"$'\n'
+    desc+="*Target Date:* ${delivery}"$'\n'
+    if [[ -n "$release_commitment" ]]; then
+        desc+="*Release Commitment:* ${release_commitment}"$'\n'
+    fi
+    desc+=$'\n'
+    desc+="h2. Testing Requirements"$'\n'
+    desc+="${testing_req:-Default probe tests only}"$'\n'
+
+    if [[ -n "$backport_versions" ]]; then
+        desc+=$'\n'
+        desc+="h2. Backport Targets"$'\n'
+        IFS=',' read -ra bp_arr <<< "$backport_versions"
+        for bp in "${bp_arr[@]}"; do
+            bp=$(echo "$bp" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            desc+="* ${bp}"$'\n'
+        done
+    fi
+
+    desc+=$'\n'
+    desc+="----"$'\n'
+    desc+="_This request was automatically created via the Claudio Package Request Skill._"
+
+    echo "$desc"
+}

--- a/claudio-plugin/skills/package-request/scripts/_production_check.sh
+++ b/claudio-plugin/skills/package-request/scripts/_production_check.sh
@@ -1,0 +1,54 @@
+# Check if a package already exists in production repository indexes.
+# Sourced by submit.sh — not executed directly.
+# Outputs PRODUCTION_WARNING and exits 0 if found.
+# Requires: normalize_pep503 from _format.sh
+
+# ---------------------------------------------------------------------------
+# Check production repositories for existing package
+# ---------------------------------------------------------------------------
+
+check_production_repos() {
+    local package_name="$1"
+    local base_url="$2"
+    local product_versions_csv="$3"
+    local variants_csv="$4"
+
+    local normalized
+    normalized=$(normalize_pep503 "$package_name")
+
+    IFS=',' read -ra versions <<< "$product_versions_csv"
+    IFS=',' read -ra variants <<< "$variants_csv"
+
+    local found_in="[]"
+    for pv in "${versions[@]}"; do
+        pv=$(echo "$pv" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        for variant in "${variants[@]}"; do
+            variant=$(echo "$variant" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            local encoded_name
+            encoded_name=$(jq -Rr '@uri' <<< "$normalized")
+            local url="${base_url}/${pv}/${variant}/simple/${encoded_name}/"
+            local http_code
+            set +e
+            http_code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 10 "$url" 2>/dev/null)
+            local rc=$?
+            set -e
+            [[ $rc -ne 0 ]] && continue
+            if [[ "$http_code" == "200" ]]; then
+                found_in=$(echo "$found_in" | jq --arg pv "$pv" --arg v "$variant" --arg u "$url" \
+                    '. + [{"product_version": $pv, "variant": $v, "repo_url": $u}]')
+            fi
+        done
+    done
+
+    local count
+    count=$(echo "$found_in" | jq 'length')
+    if [[ "$count" -gt 0 ]]; then
+        echo "PRODUCTION_WARNING"
+        jq -n --arg pkg "$package_name" --argjson found "$found_in" '{
+            warning: "production_exists",
+            message: "Note: this check does not verify whether the requested extras are available.",
+            details: {package_name: $pkg, found_in: $found}
+        }'
+        exit 0
+    fi
+}

--- a/claudio-plugin/skills/package-request/scripts/_validate.sh
+++ b/claudio-plugin/skills/package-request/scripts/_validate.sh
@@ -1,0 +1,159 @@
+# Validation functions: PyPI package existence, Jira user lookup,
+# Jira ticket existence, and duplicate request detection.
+# Sourced by submit.sh — not executed directly.
+# Requires: jira_rest, jira_site_url, jql_escape from jira-utilities _common.sh
+# Requires: output_error from _format.sh
+
+# ---------------------------------------------------------------------------
+# Validate PyPI package exists (pypi source only)
+# Blocks on 404, soft-fails on network errors.
+# ---------------------------------------------------------------------------
+
+validate_pypi() {
+    local package_name="$1"
+    local http_code
+    set +e
+    http_code=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 5 \
+        "https://pypi.org/pypi/${package_name}/json" 2>/dev/null)
+    local rc=$?
+    set -e
+    if [[ $rc -ne 0 ]]; then
+        echo "PyPI check failed (network error), proceeding" >&2
+        return 0
+    fi
+    if [[ "$http_code" == "404" ]]; then
+        output_error "VALIDATION_ERROR" \
+            "Package '${package_name}' not found on PyPI. Verify at https://pypi.org/search/?q=${package_name}"
+        exit 0
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Validate Jira user — smart retry, returns accountId on stdout.
+# Input formats: email, kerberos username, or display name.
+# ---------------------------------------------------------------------------
+
+validate_jira_user() {
+    local input="$1"
+    local attempts=()
+
+    if [[ "$input" == *" "* ]]; then
+        attempts=("$input")
+    elif [[ "$input" == *"@"* ]]; then
+        attempts=("$input" "${input%%@*}")
+    else
+        attempts=("$input" "${input}@redhat.com")
+    fi
+
+    for attempt in "${attempts[@]}"; do
+        local encoded
+        encoded=$(jq -Rr '@uri' <<< "$attempt")
+        local response
+        set +e
+        response=$(jira_rest GET "/rest/api/2/user/search?query=${encoded}&maxResults=5" 2>/dev/null)
+        local rc=$?
+        set -e
+        [[ $rc -ne 0 ]] && continue
+
+        local account_id
+        account_id=$(echo "$response" | jq -r --arg attempt "$attempt" '
+            [.[] | select(
+                (.emailAddress // "" | ascii_downcase) == ($attempt | ascii_downcase) or
+                (.displayName // "" | ascii_downcase) == ($attempt | ascii_downcase)
+            )] | first // empty | .accountId')
+
+        if [[ -n "$account_id" && "$account_id" != "null" ]]; then
+            echo "$account_id"
+            return 0
+        fi
+    done
+
+    output_error "VALIDATION_ERROR" \
+        "Unable to find requester '${input}' in Jira. Tried: ${attempts[*]}. Verify the email or username."
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Validate Jira ticket exists
+# ---------------------------------------------------------------------------
+
+validate_jira_ticket() {
+    local jira_id="$1"
+    set +e
+    jira_rest GET "/rest/api/2/issue/${jira_id}?fields=key" >/dev/null 2>&1
+    local rc=$?
+    set -e
+    if [[ $rc -ne 0 ]]; then
+        output_error "VALIDATION_ERROR" \
+            "Jira ticket '${jira_id}' not found or not accessible. Verify the ticket ID."
+        exit 0
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Check for duplicate requests (last N days).
+# Outputs DUPLICATE and exits 0 if found. Soft-fails on errors.
+# ---------------------------------------------------------------------------
+
+check_duplicates() {
+    local summary="$1"
+    local package_name="$2"
+    local extras="$3"
+    local jira_project="$4"
+    local duplicate_days="$5"
+    local max_results="$6"
+
+    local escaped_summary
+    escaped_summary=$(jql_escape "$summary")
+    local summary_conditions="summary ~ \"\\\"${escaped_summary}\\\"\""
+
+    if [[ -n "$extras" && "$extras" == *","* ]]; then
+        IFS=',' read -ra extra_arr <<< "$extras"
+        for extra in "${extra_arr[@]}"; do
+            extra=$(echo "$extra" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            local individual_summary="${package_name}[${extra}] package update request"
+            local escaped_individual
+            escaped_individual=$(jql_escape "$individual_summary")
+            summary_conditions="${summary_conditions} OR summary ~ \"\\\"${escaped_individual}\\\"\""
+        done
+    fi
+
+    local jql="project = \"${jira_project}\" AND (${summary_conditions}) AND labels = \"package\" AND created >= -${duplicate_days}d"
+    local encoded_jql
+    encoded_jql=$(jq -Rr '@uri' <<< "$jql")
+
+    local response
+    set +e
+    response=$(jira_rest GET "/rest/api/3/search/jql?jql=${encoded_jql}&maxResults=${max_results}&fields=key,summary" 2>/dev/null)
+    local rc=$?
+    set -e
+
+    if [[ $rc -ne 0 ]]; then
+        echo "Duplicate check failed, proceeding with creation" >&2
+        return 0
+    fi
+
+    local total
+    total=$(echo "$response" | jq '.issues | length')
+    if [[ "$total" -gt 0 ]]; then
+        local jira_url
+        jira_url=$(jira_site_url)
+        local existing_tickets
+        existing_tickets=$(echo "$response" | jq --arg url "$jira_url" '[.issues[] | {
+            ticket_id: .key,
+            ticket_url: ($url + "/browse/" + .key),
+            summary: (.fields.summary // "")
+        }]')
+        echo "DUPLICATE"
+        jq -n --arg pkg "$summary" \
+              --argjson tickets "$existing_tickets" \
+              --argjson total "$total" \
+              --arg days "$duplicate_days" \
+            '{
+                message: ("A request overlapping with \"" + $pkg + "\" was submitted in the past " + $days + " days."),
+                existing_tickets: $tickets,
+                total: $total
+            }'
+        exit 0
+    fi
+}

--- a/claudio-plugin/skills/package-request/scripts/list_teams.sh
+++ b/claudio-plugin/skills/package-request/scripts/list_teams.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Fetch available team components from a Jira project.
+# Usage: list_teams.sh <project>
+# Outputs: JSON array of component names, sorted alphabetically.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JIRA_UTILS="$(cd "$SCRIPT_DIR/../../jira-utilities/scripts" && pwd)"
+source "$JIRA_UTILS/_common.sh"
+
+EXIT_INVALID_PARAMS=1
+EXIT_NETWORK_ERROR=2
+EXIT_AUTH_ERROR=3
+
+project="${1:-}"
+if [[ -z "$project" ]]; then
+    echo "Usage: $0 <project>" >&2
+    echo "Example: $0 AIPCC" >&2
+    exit "$EXIT_INVALID_PARAMS"
+fi
+
+if [[ ! "$project" =~ ^[A-Z][A-Z0-9]+$ ]]; then
+    echo "Invalid project key: ${project}" >&2
+    exit "$EXIT_INVALID_PARAMS"
+fi
+
+if ! (require_env 2>/dev/null); then
+    echo "Missing required Jira environment variables (JIRA_SITE, JIRA_TOKEN, JIRA_EMAIL)" >&2
+    exit "$EXIT_AUTH_ERROR"
+fi
+
+set +e
+response=$(jira_rest GET "/rest/api/2/project/${project}/components" 2>/dev/null)
+rc=$?
+set -e
+
+if [[ $rc -ne 0 ]]; then
+    echo "Failed to fetch components from project ${project}" >&2
+    exit "$EXIT_NETWORK_ERROR"
+fi
+
+echo "$response" | jq '[.[].name] | sort'

--- a/claudio-plugin/skills/package-request/scripts/submit.sh
+++ b/claudio-plugin/skills/package-request/scripts/submit.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# Submits a package onboarding request by creating a Jira epic and triggering
+# the package-onboarding GitLab pipeline. Validates against PyPI, checks for
+# duplicates, and warns if the package already exists in production repos.
+#
+# Output protocol: first line is a result type
+# (SUCCESS | PRODUCTION_WARNING | DUPLICATE | VALIDATION_ERROR),
+# remaining lines are JSON.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JIRA_UTILS="$(cd "$SCRIPT_DIR/../../jira-utilities/scripts" && pwd)"
+source "$JIRA_UTILS/_common.sh"
+source "$SCRIPT_DIR/_format.sh"
+source "$SCRIPT_DIR/_validate.sh"
+source "$SCRIPT_DIR/_production_check.sh"
+
+EXIT_INVALID_PARAMS=1
+EXIT_NETWORK_ERROR=2
+EXIT_AUTH_ERROR=3
+
+JIRA_PROJECT="${JIRA_PROJECT:-AIPCC}"
+JIRA_COMPONENT="${JIRA_COMPONENT:-Accelerator Enablement}"
+JIRA_EPIC_NAME_FIELD="${JIRA_EPIC_NAME_FIELD:-customfield_10011}"
+JIRA_TARGET_VERSION_FIELD="${JIRA_TARGET_VERSION_FIELD:-customfield_10855}"
+PACKAGE_INDEX_BASE_URL="${PACKAGE_INDEX_BASE_URL:-https://packages.redhat.com/api/pypi/public-rhai/rhoai}"
+PACKAGE_INDEX_PRODUCT_VERSIONS="${PACKAGE_INDEX_PRODUCT_VERSIONS:-3.4,3.5}"
+PACKAGE_INDEX_VARIANTS="${PACKAGE_INDEX_VARIANTS:-cpu-ubi9}"
+DUPLICATE_CHECK_DAYS=3
+DUPLICATE_MAX_RESULTS=5
+GITLAB_PIPELINE_PROJECT="redhat/rhel-ai/core/package-onboarding"
+
+# ---------------------------------------------------------------------------
+# Jira operations (create epic, set target version)
+# ---------------------------------------------------------------------------
+
+create_epic() {
+    local summary="$1"
+    local epic_name="$2"
+    local account_id="$3"
+    local team="$4"
+    local delivery="$5"
+    local description="$6"
+
+    local team_label
+    team_label=$(sanitize_team_label "$team")
+
+    local labels_json
+    labels_json=$(jq -n --arg tl "$team_label" '["package", $tl]')
+
+    local payload
+    payload=$(jq -n \
+        --arg project "$JIRA_PROJECT" \
+        --arg summary "$summary" \
+        --arg epic_field "$JIRA_EPIC_NAME_FIELD" \
+        --arg epic_name "$epic_name" \
+        --arg account_id "$account_id" \
+        --argjson labels "$labels_json" \
+        --arg component "$JIRA_COMPONENT" \
+        --arg duedate "$delivery" \
+        --arg description "$description" \
+        '{
+            fields: {
+                project: {key: $project},
+                issuetype: {name: "Epic"},
+                summary: $summary,
+                ($epic_field): $epic_name,
+                reporter: {accountId: $account_id},
+                labels: $labels,
+                duedate: $duedate,
+                description: $description,
+                security: {name: "Red Hat Employee"}
+            }
+        }
+        | if $component != "" then .fields.components = [{name: $component}] else . end')
+
+    local response
+    set +e
+    response=$(jira_rest POST "/rest/api/2/issue" "$payload" 2>&1)
+    local rc=$?
+    set -e
+    if [[ $rc -ne 0 ]]; then
+        echo "Failed to create Jira epic: ${response}" >&2
+        exit "$EXIT_NETWORK_ERROR"
+    fi
+
+    local ticket_id
+    ticket_id=$(echo "$response" | jq -r '.key')
+    if [[ -z "$ticket_id" || "$ticket_id" == "null" ]]; then
+        echo "Failed to parse ticket ID from response: ${response}" >&2
+        exit "$EXIT_NETWORK_ERROR"
+    fi
+
+    echo "$ticket_id"
+}
+
+update_target_version() {
+    local ticket_id="$1"
+    local release_target="$2"
+
+    local versions_json
+    versions_json=$(echo "$release_target" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map({name: .})')
+
+    local payload
+    payload=$(jq -n --arg field "$JIRA_TARGET_VERSION_FIELD" --argjson versions "$versions_json" \
+        '{fields: {($field): $versions}}')
+
+    set +e
+    jira_rest PUT "/rest/api/2/issue/${ticket_id}" "$payload" >/dev/null 2>&1
+    local rc=$?
+    set -e
+    if [[ $rc -ne 0 ]]; then
+        echo "Warning: Failed to set Target Version on ${ticket_id}" >&2
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# GitLab pipeline trigger (non-blocking)
+# ---------------------------------------------------------------------------
+
+trigger_pipeline() {
+    local package_with_extras="$1"
+    local ticket_id="$2"
+    local version="${3:-}"
+
+    if [[ -z "${GITLAB_TOKEN:-}" ]]; then
+        echo "Warning: GITLAB_TOKEN not set, skipping pipeline trigger" >&2
+        return 0
+    fi
+
+    if ! command -v glab >/dev/null 2>&1; then
+        echo "Warning: glab not found, skipping pipeline trigger" >&2
+        return 0
+    fi
+
+    local vars_file
+    vars_file=$(mktemp /tmp/pipeline-vars-XXXXXX.json)
+    trap 'rm -f "$vars_file"' RETURN
+
+    jq -n \
+        --arg pkg "$package_with_extras" \
+        --arg tid "$ticket_id" \
+        '[{key: "PACKAGE_NAME", value: $pkg}, {key: "JIRA_TICKET_ID", value: $tid}]' > "$vars_file"
+    if [[ -n "$version" ]]; then
+        local updated
+        updated=$(jq --arg ver "$version" '. + [{key: "PACKAGE_VERSION", value: $ver}]' "$vars_file")
+        printf '%s' "$updated" > "$vars_file"
+    fi
+
+    local output
+    set +e
+    output=$(glab ci run -R "$GITLAB_PIPELINE_PROJECT" -b main --variables-from "$vars_file" 2>&1)
+    local rc=$?
+    set -e
+
+    if [[ $rc -ne 0 ]]; then
+        echo "Warning: Pipeline trigger failed: ${output}" >&2
+        return 0
+    fi
+
+    local pipeline_url
+    pipeline_url=$(echo "$output" | grep -oE 'https://[^ ]*pipelines/[0-9]+' | head -1)
+    if [[ -z "$pipeline_url" ]]; then
+        pipeline_url=$(echo "$output" | grep -oE 'https://[^ ]+' | head -1)
+    fi
+    echo "${pipeline_url:-}"
+}
+
+# ===========================================================================
+# Arg parsing
+# ===========================================================================
+
+package_name=""
+requester=""
+team=""
+jira_id=""
+justification=""
+delivery_timeline=""
+
+extras=""
+package_source=""
+source_url=""
+version=""
+backport_versions=""
+release_target=""
+release_commitment=""
+other_hardware=""
+testing_requirements=""
+skip_production_check=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --package-name)        package_name="$2"; shift 2 ;;
+        --requester)           requester="$2"; shift 2 ;;
+        --team)                team="$2"; shift 2 ;;
+        --jira-id)             jira_id="$2"; shift 2 ;;
+        --justification)       justification="$2"; shift 2 ;;
+        --delivery-timeline)   delivery_timeline="$2"; shift 2 ;;
+        --extras)              extras="$2"; shift 2 ;;
+        --package-source)      package_source="$2"; shift 2 ;;
+        --source-url)          source_url="$2"; shift 2 ;;
+        --version)             version="$2"; shift 2 ;;
+        --backport-versions)   backport_versions="$2"; shift 2 ;;
+        --release-target)      release_target="$2"; shift 2 ;;
+        --release-commitment)  release_commitment="$2"; shift 2 ;;
+        --other-hardware)      other_hardware="$2"; shift 2 ;;
+        --testing-requirements) testing_requirements="$2"; shift 2 ;;
+        --skip-production-check) skip_production_check=true; shift ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit "$EXIT_INVALID_PARAMS"
+            ;;
+    esac
+done
+
+# ===========================================================================
+# Validate required fields
+# ===========================================================================
+
+missing=()
+[[ -z "$package_name" ]]      && missing+=("--package-name")
+[[ -z "$requester" ]]         && missing+=("--requester")
+[[ -z "$team" ]]              && missing+=("--team")
+[[ -z "$jira_id" ]]           && missing+=("--jira-id")
+[[ -z "$justification" ]]     && missing+=("--justification")
+[[ -z "$delivery_timeline" ]] && missing+=("--delivery-timeline")
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "Missing required arguments: ${missing[*]}" >&2
+    exit "$EXIT_INVALID_PARAMS"
+fi
+
+if ! [[ "$delivery_timeline" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    echo "Invalid --delivery-timeline format: '${delivery_timeline}'. Must be YYYY-MM-DD." >&2
+    exit "$EXIT_INVALID_PARAMS"
+fi
+
+# Parse extras from package name if present (e.g. torch[cuda,tensor])
+if [[ "$package_name" == *"["*"]" ]]; then
+    parsed_extras="${package_name#*\[}"
+    parsed_extras="${parsed_extras%\]}"
+    package_name="${package_name%%\[*}"
+    if [[ -n "$extras" ]]; then
+        extras="${parsed_extras},${extras}"
+    else
+        extras="$parsed_extras"
+    fi
+fi
+
+# Deduplicate extras
+if [[ -n "$extras" ]]; then
+    extras=$(echo "$extras" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sort -u | paste -sd, -)
+fi
+
+package_with_extras="$package_name"
+if [[ -n "$extras" ]]; then
+    package_with_extras="${package_name}[${extras}]"
+fi
+
+summary="${package_with_extras} package update request"
+epic_name="${package_name} package update request"
+
+# Validate env vars (subshell because require_env calls exit directly)
+if ! (require_env 2>/dev/null); then
+    echo "Missing required Jira environment variables (JIRA_SITE, JIRA_TOKEN, JIRA_EMAIL)" >&2
+    exit "$EXIT_AUTH_ERROR"
+fi
+
+# ===========================================================================
+# Execution flow
+# ===========================================================================
+
+pkg_source="${package_source:-pypi}"
+if [[ "$pkg_source" == "pypi" ]]; then
+    validate_pypi "$package_name"
+fi
+
+account_id=$(validate_jira_user "$requester")
+if [[ "$account_id" == VALIDATION_ERROR* ]]; then
+    echo "$account_id"
+    exit 0
+fi
+
+validate_jira_ticket "$jira_id"
+
+check_duplicates "$summary" "$package_name" "$extras" "$JIRA_PROJECT" "$DUPLICATE_CHECK_DAYS" "$DUPLICATE_MAX_RESULTS"
+
+if [[ "$skip_production_check" != true ]]; then
+    check_production_repos "$package_name" "$PACKAGE_INDEX_BASE_URL" "$PACKAGE_INDEX_PRODUCT_VERSIONS" "$PACKAGE_INDEX_VARIANTS"
+fi
+
+description=$(format_description \
+    "$requester" "$team" "$package_name" "$pkg_source" "$source_url" \
+    "$version" "$extras" "$other_hardware" "$jira_id" "$justification" \
+    "$delivery_timeline" "$release_commitment" "$testing_requirements" \
+    "$backport_versions")
+
+ticket_id=$(create_epic "$summary" "$epic_name" "$account_id" "$team" "$delivery_timeline" "$description")
+jira_url=$(jira_site_url)
+ticket_url="${jira_url}/browse/${ticket_id}"
+
+if [[ -n "$release_target" ]]; then
+    update_target_version "$ticket_id" "$release_target"
+fi
+
+pipeline_url=$(trigger_pipeline "$package_with_extras" "$ticket_id" "$version")
+
+echo "SUCCESS"
+jq -n \
+    --arg tid "$ticket_id" \
+    --arg turl "$ticket_url" \
+    --arg pkg "$package_with_extras" \
+    --arg msg "Package request created successfully" \
+    --arg purl "${pipeline_url:-}" \
+    '{
+        ticket_id: $tid,
+        ticket_url: $turl,
+        package_name: $pkg,
+        message: $msg
+    }
+    | if $purl != "" then . + {pipeline_url: $purl} else . end'

--- a/claudio-plugin/tools/redhat-ca/install.sh
+++ b/claudio-plugin/tools/redhat-ca/install.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../common.sh
+source "$SCRIPT_DIR/../common.sh"
+
+CERT_URL="https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem"
+CERT_SHA256="e9713aed04b4ef3003edd10fc9c4f8ab875436e4a44195f0cbafcdf95e9bad2c"
+CERT_FILE="redhat-it-root-cas.pem"
+ANCHOR_DIR="/etc/pki/ca-trust/source/anchors"
+
+check_cert() {
+    if [ -f "$ANCHOR_DIR/$CERT_FILE" ]; then
+        local existing_sha
+        existing_sha=$(sha256sum "$ANCHOR_DIR/$CERT_FILE" 2>/dev/null | cut -d' ' -f1)
+        if [ "$existing_sha" = "$CERT_SHA256" ]; then
+            log "Red Hat IT Root CA is already installed"
+            return 0
+        fi
+        log "Installed Red Hat IT Root CA does not match the pinned hash — reinstalling"
+        return 1
+    fi
+    log "Red Hat IT Root CA is not installed"
+    return 1
+}
+
+install_cert() {
+    verify_linux || return 1
+
+    if [ "$EUID" -ne 0 ]; then
+        log "ERROR: Must run as root or via sudo" >&2
+        return 1
+    fi
+
+    if [ ! -d "$ANCHOR_DIR" ]; then
+        log "ERROR: $ANCHOR_DIR does not exist — is this a RHEL/UBI system?" >&2
+        return 1
+    fi
+
+    local tmp_cert
+    tmp_cert=$(mktemp /tmp/redhat-ca-XXXXXX.pem)
+    trap 'rm -f "$tmp_cert"' RETURN
+
+    log "Downloading Red Hat IT Root CA from $CERT_URL..."
+    if ! curl -ksS --fail --connect-timeout 10 --max-time 30 "$CERT_URL" -o "$tmp_cert"; then
+        log "WARNING: Could not download Red Hat IT Root CA — host may not be reachable" >&2
+        return 1
+    fi
+
+    if ! grep -q "BEGIN CERTIFICATE" "$tmp_cert"; then
+        log "ERROR: Downloaded file is not a valid PEM certificate" >&2
+        return 1
+    fi
+
+    local actual_sha
+    actual_sha=$(sha256sum "$tmp_cert" | cut -d' ' -f1)
+    if [ "$actual_sha" != "$CERT_SHA256" ]; then
+        log "ERROR: Certificate hash mismatch (expected $CERT_SHA256, got $actual_sha)" >&2
+        return 1
+    fi
+
+    mv "$tmp_cert" "$ANCHOR_DIR/$CERT_FILE"
+
+    if ! command_exists update-ca-trust; then
+        log "ERROR: update-ca-trust not found" >&2
+        rm -f "$ANCHOR_DIR/$CERT_FILE"
+        return 1
+    fi
+
+    if ! update-ca-trust; then
+        log "ERROR: Failed to update the system trust store" >&2
+        rm -f "$ANCHOR_DIR/$CERT_FILE"
+        return 1
+    fi
+    log "✓ Red Hat IT Root CA installed and trust store updated"
+}
+
+main() {
+    if [ "${1:-}" = "--check" ] || [ "${1:-}" = "-c" ]; then
+        check_cert
+        exit $?
+    fi
+
+    if ! check_cert; then
+        install_cert
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Adds a skill for submitting package onboarding requests via direct Jira REST API and GitLab CI. Collects required fields conversationally, creates a Jira epic with "Red Hat Employee" security level, and triggers the package-onboarding pipeline via `glab ci run`.

Also adds a Red Hat IT Root CA install script (`tools/redhat-ca/`) that downloads the cert from `certs.corp.redhat.com` at build time, so skills can reach Red Hat internal TLS endpoints without runtime workarounds.

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Rishabh Kothari <rkothari@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Package Request** workflow to create Jira onboarding Epics and best-effort trigger related GitLab pipelines.
  * Provides guided, interactive input collection with format/timeline validation, PyPI existence checks, duplicate detection, and production-repo availability warnings.
  * Allows submitting additional requests in the same session and reports outcomes with clear status messaging.
* **Documentation**
  * Updated the main README and added a dedicated Package Request skill guide with required tools, environment variables, and expected behaviors.
* **Chores**
  * Added a pinned Red Hat IT Root CA installer with verification and a `--check` mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->